### PR TITLE
fix(docker): resolve zallet permission error by relocating config mounts

### DIFF
--- a/config/zallet.toml
+++ b/config/zallet.toml
@@ -41,7 +41,7 @@ validator_cookie_path = "/var/run/auth/.cookie"
 
 [keystore]
 # Age encryption identity file (mounted from ./config/zallet_identity.txt)
-encryption_identity = "identity.txt"
+encryption_identity = "/etc/zallet/identity.txt"
 
 [note_management]
 # Note management - using defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     container_name: z3_zallet
     restart: unless-stopped
     user: "65532:65532"
-    command: ["--datadir", "/var/lib/zallet", "start"]
+    command: ["--datadir", "/var/lib/zallet", "--config", "/etc/zallet/zallet.toml", "start"]
     depends_on:
       zebra:
         condition: service_healthy
@@ -116,9 +116,9 @@ services:
       - ${Z3_ZALLET_DATA_PATH}:/var/lib/zallet
       # Cookie authentication for Zebra access
       - ${Z3_COOKIE_PATH}:${COOKIE_AUTH_FILE_DIR}:ro
-      # Configuration files
-      - ./config/zallet.toml:/var/lib/zallet/zallet.toml:ro
-      - ./config/zallet_identity.txt:/var/lib/zallet/identity.txt:ro
+      # Configuration files (mounted outside datadir to avoid permission conflicts)
+      - ./config/zallet.toml:/etc/zallet/zallet.toml:ro
+      - ./config/zallet_identity.txt:/etc/zallet/identity.txt:ro
     ports:
       - "${ZALLET_HOST_RPC_PORT}:${ZALLET_RPC_PORT}"
     networks:


### PR DESCRIPTION
## Motivation

When running the Z3 stack, zallet fails to start with "Permission denied (os error 13)" during database initialization. This issue was reported in #9 and affects multiple users.

The root cause is overlapping Docker mounts in docker-compose.yml. Config files were bind-mounted inside the data volume (`/var/lib/zallet/`), causing Docker to create them with root ownership (UID 0:0) while the container runs as the nonroot user (UID 65532).

## Solution

This PR fixes the permission error by relocating config file mounts outside the data directory:

- Mount config files to `/etc/zallet/` instead of `/var/lib/zallet/`
- Add `--config /etc/zallet/zallet.toml` flag to zallet command (zallet supports this flag per `zallet/src/cli.rs:40-44`)
- Update `encryption_identity` path in zallet.toml to absolute path `/etc/zallet/identity.txt`

**Why this works:**
1. Config files are no longer inside the data volume - no ownership conflicts
2. Bind mounts don't overlap the volume - Docker handles permissions correctly
3. Container user (65532) can read bind-mounted files outside the volume

**Files changed:**
- `docker-compose.yml` - Updated zallet command and volume mount paths
- `config/zallet.toml` - Changed encryption_identity to absolute path

**Note:** This fix works on both mainnet and testnet as it addresses Docker mount configuration, not network-specific settings.

## Test plan

- [x] Tested on testnet with default configuration
- [x] Verified zallet container starts successfully (no crashes/restarts)
- [x] Confirmed database migrations complete without permission errors
- [x] Validated zallet's embedded Zaino indexer connects to Zebra
- [x] Verified in Zebra source that `--config` flag is supported (zallet/src/cli.rs:40-44)

**Before fix:**
```
Failed to initialize zallet: Permission denied (os error 13)
```

**After fix:**
```
[INFO] zallet::components::database: Applying latest database migrations
[INFO] schemerz: Migrating everything
[INFO] zallet::components::chain_view: Starting Zaino indexer
```

Closes #9