### PR TITLE
feat: add optional zcashd compose profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@
 # Platform (ARM64 users: uncomment for native Z3 service images)
 # =============================================================================
 # DOCKER_PLATFORM=linux/arm64
-# The official zcashd image is linux/amd64; only change this for a custom arm64 image.
+# The default zcashd image is linux/amd64; only change this for a custom arm64 image.
 # ZCASHD_DOCKER_PLATFORM=linux/amd64
 
 # =============================================================================
@@ -37,7 +37,7 @@
 # ZEBRA_IMAGE=zfnd/zebra:4.3.1
 # ZAINO_IMAGE=ghcr.io/zcashfoundation/zaino:sha-83e41d7
 # ZALLET_IMAGE=electriccoinco/zallet:v0.1.0-alpha.3
-# ZCASHD_IMAGE=electriccoinco/zcashd:latest
+# ZCASHD_IMAGE=zodlinc/zcashd:v6.12.1
 # ZEBRA_BUILD_FEATURES=default-release-binaries
 
 # =============================================================================
@@ -47,7 +47,6 @@
 # Z3_ZAINO_DATA_PATH=zaino_data
 # Z3_ZALLET_DATA_PATH=zallet_data
 # Z3_ZCASHD_DATA_PATH=zcashd_data
-# Z3_ZCASHD_PARAMS_PATH=zcashd_params
 # Z3_COOKIE_PATH=shared_cookie_volume
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@
 #   Mainnet (default): docker compose up -d
 #   Testnet:           create .env with NETWORK_NAME=Testnet
 #   Regtest:           docker compose --env-file .env.regtest up -d
+#   zcashd comparator: add --profile zcashd to include optional zcashd
 #
 #   Variable                             Mainnet   Testnet   Regtest
 #   ─────────────────────────────────────────────────────────────────
@@ -24,9 +25,11 @@
 # ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1
 
 # =============================================================================
-# Platform (ARM64 users: uncomment for native builds)
+# Platform (ARM64 users: uncomment for native Z3 service images)
 # =============================================================================
 # DOCKER_PLATFORM=linux/arm64
+# The official zcashd image is linux/amd64; only change this for a custom arm64 image.
+# ZCASHD_DOCKER_PLATFORM=linux/amd64
 
 # =============================================================================
 # Image Overrides (defaults are pinned versions in docker-compose.yml)
@@ -34,6 +37,7 @@
 # ZEBRA_IMAGE=zfnd/zebra:4.3.0
 # ZAINO_IMAGE=ghcr.io/zcashfoundation/zaino:sha-83e41d7
 # ZALLET_IMAGE=electriccoinco/zallet:v0.1.0-alpha.3
+# ZCASHD_IMAGE=electriccoinco/zcashd:latest
 # ZEBRA_BUILD_FEATURES=default-release-binaries
 
 # =============================================================================
@@ -42,6 +46,8 @@
 # Z3_ZEBRA_DATA_PATH=zebra_data
 # Z3_ZAINO_DATA_PATH=zaino_data
 # Z3_ZALLET_DATA_PATH=zallet_data
+# Z3_ZCASHD_DATA_PATH=zcashd_data
+# Z3_ZCASHD_PARAMS_PATH=zcashd_params
 # Z3_COOKIE_PATH=shared_cookie_volume
 
 # =============================================================================
@@ -52,6 +58,8 @@
 # ZAINO_HOST_GRPC_PORT=8137
 # ZAINO_HOST_JSONRPC_PORT=8237
 # ZALLET_HOST_RPC_PORT=28232
+# ZCASHD_HOST_RPC_BIND=127.0.0.1
+# ZCASHD_HOST_RPC_PORT=38232
 
 # =============================================================================
 # Internal Container Ports (change only for advanced multi-instance setups)
@@ -61,6 +69,7 @@
 # ZAINO_GRPC_PORT=8137
 # ZAINO_JSON_RPC_PORT=8237
 # ZALLET_RPC_PORT=28232
+# ZCASHD_RPC_PORT=38232
 
 # =============================================================================
 # Log Levels
@@ -70,6 +79,21 @@
 # ZAINO_RUST_LOG=info,reqwest=warn,hyper_util=warn
 # ZAINO_RUST_BACKTRACE=full
 # ZALLET_RUST_LOG=info,hyper_util=warn,reqwest=warn
+
+# =============================================================================
+# Optional zcashd Comparator (enable with: docker compose --profile zcashd up -d zcashd)
+# =============================================================================
+# ZCASHD_RPCUSER=zebra
+# ZCASHD_RPCPASSWORD=zebra
+# ZCASHD_RPC_ALLOWIP=0.0.0.0/0
+# Regtest activation overrides for custom comparator runs.
+# Defaults keep zcashd aligned with the standard Z3 regtest stack.
+# ZCASHD_OVERWINTER_ACTIVATION_HEIGHT=1
+# ZCASHD_SAPLING_ACTIVATION_HEIGHT=1
+# ZCASHD_BLOSSOM_ACTIVATION_HEIGHT=1
+# ZCASHD_HEARTWOOD_ACTIVATION_HEIGHT=1
+# ZCASHD_CANOPY_ACTIVATION_HEIGHT=1
+# ZCASHD_NU5_ACTIVATION_HEIGHT=1
 
 # =============================================================================
 # Monitoring (enable with: docker compose --profile monitoring up -d)

--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@
 # =============================================================================
 # Image Overrides (defaults are pinned versions in docker-compose.yml)
 # =============================================================================
-# ZEBRA_IMAGE=zfnd/zebra:4.3.0
+# ZEBRA_IMAGE=zfnd/zebra:4.3.1
 # ZAINO_IMAGE=ghcr.io/zcashfoundation/zaino:sha-83e41d7
 # ZALLET_IMAGE=electriccoinco/zallet:v0.1.0-alpha.3
 # ZCASHD_IMAGE=electriccoinco/zcashd:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,8 @@ jobs:
           mkdir -p config/tls config/regtest
           openssl req -x509 -newkey rsa:2048 \
             -keyout config/tls/zaino.key -out config/tls/zaino.crt \
-            -sha256 -days 1 -nodes -subj "/CN=localhost" 2>/dev/null
+            -sha256 -days 1 -nodes -subj "/CN=localhost" \
+            -addext "subjectAltName=DNS:localhost,DNS:zaino,IP:127.0.0.1" 2>/dev/null
           chmod 644 config/tls/zaino.key config/tls/zaino.crt
           echo "# dummy identity for CI" > config/regtest/zallet_identity.txt
           SALT=$(openssl rand -hex 16)
@@ -39,6 +40,7 @@ jobs:
         run: |
           docker compose config --quiet
           docker compose --env-file .env.regtest config --quiet
+          docker compose --env-file .env.regtest --profile zcashd config --quiet
 
       - name: Start Zebra (regtest)
         run: |
@@ -87,6 +89,26 @@ jobs:
             sleep 2
           done
 
+      - name: Start zcashd comparator and verify RPC
+        run: |
+          docker compose --env-file .env.regtest --profile zcashd up -d zcashd
+          echo "Waiting for zcashd RPC..."
+          for i in $(seq 1 30); do
+            if RESULT=$(curl -sf -u zebra:zebra -X POST -H "Content-Type: application/json" \
+              -d '{"jsonrpc":"2.0","method":"getblockchaininfo","params":[],"id":1}' \
+              http://127.0.0.1:38232 2>/dev/null); then
+              echo "zcashd is ready"
+              echo "$RESULT" | jq .
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "zcashd failed to start"
+              docker compose --env-file .env.regtest --profile zcashd logs zcashd --tail 50
+              exit 1
+            fi
+            sleep 2
+          done
+
       - name: Verify Zallet accepts compose command
         run: docker compose --env-file .env.regtest run --rm --no-deps zallet --help
 
@@ -97,5 +119,7 @@ jobs:
           docker compose --env-file .env.regtest logs zebra --tail 50 2>&1 || true
           echo "=== Zaino logs ==="
           docker compose --env-file .env.regtest logs zaino --tail 50 2>&1 || true
+          echo "=== zcashd logs ==="
+          docker compose --env-file .env.regtest --profile zcashd logs zcashd --tail 50 2>&1 || true
           echo "=== Container status ==="
-          docker compose --env-file .env.regtest ps 2>&1 || true
+          docker compose --env-file .env.regtest --profile zcashd ps 2>&1 || true

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ config/tls/*
 # Runtime environment overrides (see .env.example for available variables)
 .env
 
+# Local comparator state
+.tmp/
+
 # Ignore docker compose overrides
 docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All images can be overridden via environment variables (`ZEBRA_IMAGE`, `ZAINO_IM
 
 | Service | Default Image | Source |
 |---------|---------------|--------|
-| Zebra | `zfnd/zebra:4.3.0` | [ZcashFoundation/zebra](https://github.com/ZcashFoundation/zebra) |
+| Zebra | `zfnd/zebra:4.3.1` | [ZcashFoundation/zebra](https://github.com/ZcashFoundation/zebra) |
 | Zaino | `ghcr.io/zcashfoundation/zaino:sha-83e41d7` | [zingolabs/zaino](https://github.com/zingolabs/zaino) |
 | Zallet | `electriccoinco/zallet:v0.1.0-alpha.3` | [zcash/wallet](https://github.com/zcash/wallet) |
 | zcashd | `electriccoinco/zcashd:latest` | [zcash/zcash](https://github.com/zcash/zcash) |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker compose ps    # verify all healthy
 ```
 
 > [!TIP]
-> **Apple Silicon users:** Create `.env` with `DOCKER_PLATFORM=linux/arm64` for native builds.
+> **Apple Silicon users:** Set `DOCKER_PLATFORM=linux/arm64` for native Z3 services. The optional zcashd profile has a separate platform setting.
 
 ## Deployment Modes
 
@@ -79,6 +79,20 @@ docker compose --env-file .env.regtest up -d
 The init script generates the Zallet RPC password hash, starts Zebra, mines the first block, and initializes the Zallet wallet. It is safe to re-run — it skips steps that are already done. Subsequent runs only need the last command.
 
 See [docs/regtest.md](docs/regtest.md) for test commands (curl, grpcurl) and the full workflow reference.
+
+### Optional zcashd Comparator
+
+`zcashd` is available behind an opt-in Compose profile for local comparison tests. It is not part of the default Z3 stack, uses separate data and params volumes, exposes RPC on `http://localhost:38232`, and starts with public P2P disabled (`-listen=0 -connect=0`).
+
+```bash
+# Mainnet/testnet-style comparator
+docker compose --profile zcashd up -d zcashd
+
+# Regtest comparator with the regtest overlay
+docker compose --env-file .env.regtest --profile zcashd up -d zcashd
+```
+
+The default image is the official `electriccoinco/zcashd:latest` image. Default RPC credentials are `zebra` / `zebra`; override them with `ZCASHD_RPCUSER` and `ZCASHD_RPCPASSWORD`. For custom regtest runs, zcashd activation heights can be overridden with `ZCASHD_*_ACTIVATION_HEIGHT` variables; use a separate `Z3_ZCASHD_DATA_PATH` when changing them.
 
 ### Monitoring Stack
 
@@ -122,13 +136,14 @@ graph LR
 
 **Zebra** syncs and validates the Zcash blockchain. **Zaino** provides a lightwalletd-compatible gRPC interface for light wallet clients like Zingo. **Zallet** embeds Zaino's indexer libraries internally and connects directly to Zebra's JSON-RPC; it does not use the standalone Zaino service.
 
-All images can be overridden via environment variables (`ZEBRA_IMAGE`, `ZAINO_IMAGE`, `ZALLET_IMAGE`). See `.env.example` for all available options.
+All images can be overridden via environment variables (`ZEBRA_IMAGE`, `ZAINO_IMAGE`, `ZALLET_IMAGE`, `ZCASHD_IMAGE`). See `.env.example` for all available options.
 
 | Service | Default Image | Source |
 |---------|---------------|--------|
 | Zebra | `zfnd/zebra:4.3.0` | [ZcashFoundation/zebra](https://github.com/ZcashFoundation/zebra) |
 | Zaino | `ghcr.io/zcashfoundation/zaino:sha-83e41d7` | [zingolabs/zaino](https://github.com/zingolabs/zaino) |
 | Zallet | `electriccoinco/zallet:v0.1.0-alpha.3` | [zcash/wallet](https://github.com/zcash/wallet) |
+| zcashd | `electriccoinco/zcashd:latest` | [zcash/zcash](https://github.com/zcash/zcash) |
 
 ## Prerequisites
 
@@ -150,6 +165,7 @@ Once running, services are available at:
 | Zaino gRPC | `localhost:8137` | `ZAINO_HOST_GRPC_PORT` |
 | Zaino JSON-RPC | `http://localhost:8237` | `ZAINO_HOST_JSONRPC_PORT` |
 | Zallet RPC | `http://localhost:28232` | `ZALLET_HOST_RPC_PORT` |
+| zcashd RPC | `http://localhost:38232` | `ZCASHD_HOST_RPC_PORT` |
 
 ## Stopping the Stack
 
@@ -242,11 +258,13 @@ Critical requirements for `config/zallet.toml`:
 
 ### Platform Configuration (ARM64)
 
-Z3 defaults to AMD64 for consistency. On Apple Silicon or ARM64 Linux, emulation makes builds ~15x slower. Enable native builds:
+Z3 defaults to AMD64 for consistency. On Apple Silicon or ARM64 Linux, enable native Zebra, Zaino, and Zallet images:
 
 ```bash
 echo "DOCKER_PLATFORM=linux/arm64" >> .env
 ```
+
+The optional zcashd service has a separate `ZCASHD_DOCKER_PLATFORM` setting. Keep the default `linux/amd64` when using `electriccoinco/zcashd:latest`; Docker Desktop runs it through emulation on Apple Silicon. Only set `ZCASHD_DOCKER_PLATFORM=linux/arm64` when `ZCASHD_IMAGE` points to an arm64-capable image.
 
 </details>
 
@@ -307,6 +325,8 @@ The stack uses Docker-managed named volumes by default:
 | `zebra_data` | Blockchain state (~300 GB mainnet, ~30 GB testnet) |
 | `zaino_data` | Indexer database |
 | `zallet_data` | Wallet database |
+| `zcashd_data` | Optional zcashd comparator chain state |
+| `zcashd_params` | Optional zcashd comparator params cache |
 | `shared_cookie_volume` | RPC authentication cookies |
 
 ### Local Directories (Advanced)
@@ -327,7 +347,7 @@ Fix permissions before starting:
 ./scripts/fix-permissions.sh zallet /mnt/ssd/zallet-data
 ```
 
-Each service runs as a specific non-root user. Directories must have correct ownership (set by the script) and 700 permissions. Never use 755 or 777.
+Zebra, Zaino, and Zallet each run as a specific non-root user. Directories must have correct ownership (set by the script) and 700 permissions. Never use 755 or 777.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See [docs/regtest.md](docs/regtest.md) for test commands (curl, grpcurl) and the
 
 ### Optional zcashd Comparator
 
-`zcashd` is available behind an opt-in Compose profile for local comparison tests. It is not part of the default Z3 stack, uses separate data and params volumes, exposes RPC on `http://localhost:38232`, and starts with public P2P disabled (`-listen=0 -connect=0`).
+`zcashd` is available behind an opt-in Compose profile for local comparison tests. It is not part of the default Z3 stack, uses a separate data volume, exposes RPC on `http://localhost:38232`, and starts with public P2P disabled (`-listen=0 -connect=0`).
 
 ```bash
 # Mainnet/testnet-style comparator
@@ -92,7 +92,7 @@ docker compose --profile zcashd up -d zcashd
 docker compose --env-file .env.regtest --profile zcashd up -d zcashd
 ```
 
-The default image is the official `electriccoinco/zcashd:latest` image. Default RPC credentials are `zebra` / `zebra`; override them with `ZCASHD_RPCUSER` and `ZCASHD_RPCPASSWORD`. For custom regtest runs, zcashd activation heights can be overridden with `ZCASHD_*_ACTIVATION_HEIGHT` variables; use a separate `Z3_ZCASHD_DATA_PATH` when changing them.
+The default image is `zodlinc/zcashd:v6.12.1`. Default RPC credentials are `zebra` / `zebra`; override them with `ZCASHD_RPCUSER` and `ZCASHD_RPCPASSWORD`. For custom regtest runs, zcashd activation heights can be overridden with `ZCASHD_*_ACTIVATION_HEIGHT` variables; use a separate `Z3_ZCASHD_DATA_PATH` when changing them.
 
 ### Monitoring Stack
 
@@ -143,7 +143,7 @@ All images can be overridden via environment variables (`ZEBRA_IMAGE`, `ZAINO_IM
 | Zebra | `zfnd/zebra:4.3.1` | [ZcashFoundation/zebra](https://github.com/ZcashFoundation/zebra) |
 | Zaino | `ghcr.io/zcashfoundation/zaino:sha-83e41d7` | [zingolabs/zaino](https://github.com/zingolabs/zaino) |
 | Zallet | `electriccoinco/zallet:v0.1.0-alpha.3` | [zcash/wallet](https://github.com/zcash/wallet) |
-| zcashd | `electriccoinco/zcashd:latest` | [zcash/zcash](https://github.com/zcash/zcash) |
+| zcashd | `zodlinc/zcashd:v6.12.1` | [zcash/zcash](https://github.com/zcash/zcash) |
 
 ## Prerequisites
 
@@ -264,7 +264,7 @@ Z3 defaults to AMD64 for consistency. On Apple Silicon or ARM64 Linux, enable na
 echo "DOCKER_PLATFORM=linux/arm64" >> .env
 ```
 
-The optional zcashd service has a separate `ZCASHD_DOCKER_PLATFORM` setting. Keep the default `linux/amd64` when using `electriccoinco/zcashd:latest`; Docker Desktop runs it through emulation on Apple Silicon. Only set `ZCASHD_DOCKER_PLATFORM=linux/arm64` when `ZCASHD_IMAGE` points to an arm64-capable image.
+The optional zcashd service has a separate `ZCASHD_DOCKER_PLATFORM` setting. Keep the default `linux/amd64` when using `zodlinc/zcashd:v6.12.1`; Docker Desktop runs it through emulation on Apple Silicon. Only set `ZCASHD_DOCKER_PLATFORM=linux/arm64` when `ZCASHD_IMAGE` points to an arm64-capable image.
 
 </details>
 
@@ -326,7 +326,6 @@ The stack uses Docker-managed named volumes by default:
 | `zaino_data` | Indexer database |
 | `zallet_data` | Wallet database |
 | `zcashd_data` | Optional zcashd comparator chain state |
-| `zcashd_params` | Optional zcashd comparator params cache |
 | `shared_cookie_volume` | RPC authentication cookies |
 
 ### Local Directories (Advanced)
@@ -337,6 +336,7 @@ For backups, external SSDs, or shared storage, override volume paths in `.env`:
 Z3_ZEBRA_DATA_PATH=/mnt/ssd/zebra-state
 Z3_ZAINO_DATA_PATH=/mnt/ssd/zaino-data
 Z3_ZALLET_DATA_PATH=/mnt/ssd/zallet-data
+Z3_ZCASHD_DATA_PATH=/mnt/ssd/zcashd-data
 ```
 
 Fix permissions before starting:
@@ -345,9 +345,10 @@ Fix permissions before starting:
 ./scripts/fix-permissions.sh zebra /mnt/ssd/zebra-state
 ./scripts/fix-permissions.sh zaino /mnt/ssd/zaino-data
 ./scripts/fix-permissions.sh zallet /mnt/ssd/zallet-data
+./scripts/fix-permissions.sh zcashd /mnt/ssd/zcashd-data
 ```
 
-Zebra, Zaino, and Zallet each run as a specific non-root user. Directories must have correct ownership (set by the script) and 700 permissions. Never use 755 or 777.
+Zebra, Zaino, Zallet, and zcashd each run as a specific non-root user. Directories must have correct ownership (set by the script) and 700 permissions. Never use 755 or 777.
 
 </details>
 

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -49,6 +49,9 @@ services:
     # from P2P in regtest. Activation heights default to config/regtest/zallet.toml
     # but can be overridden for custom regtest runs.
     command:
+      - zcashd
+      - -conf=/dev/null
+      - -printtoconsole
       - -regtest
       - -i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
       - -listen=0
@@ -56,6 +59,11 @@ services:
       - -dns=0
       - -connect=0
       - -server=1
+      - -rpcuser=${ZCASHD_RPCUSER:-zebra}
+      - -rpcpassword=${ZCASHD_RPCPASSWORD:-zebra}
+      - -rpcbind=0.0.0.0
+      - -rpcport=${ZCASHD_RPC_PORT:-38232}
+      - -rpcallowip=${ZCASHD_RPC_ALLOWIP:-0.0.0.0/0}
       - -nuparams=5ba81b19:${ZCASHD_OVERWINTER_ACTIVATION_HEIGHT:-1}
       - -nuparams=76b809bb:${ZCASHD_SAPLING_ACTIVATION_HEIGHT:-1}
       - -nuparams=2bb40e60:${ZCASHD_BLOSSOM_ACTIVATION_HEIGHT:-1}
@@ -63,7 +71,7 @@ services:
       - -nuparams=e9ff75a6:${ZCASHD_CANOPY_ACTIVATION_HEIGHT:-1}
       - -nuparams=c2d6d0b4:${ZCASHD_NU5_ACTIVATION_HEIGHT:-1}
     healthcheck:
-      test: ["CMD-SHELL", "zcash-cli -regtest -rpcconnect=127.0.0.1 -rpcport=$${ZCASHD_RPCPORT} -rpcuser=$${ZCASHD_RPCUSER} -rpcpassword=$${ZCASHD_RPCPASSWORD} getblockchaininfo >/dev/null"]
+      test: ["CMD-SHELL", "zcash-cli -conf=/dev/null -regtest -rpcconnect=127.0.0.1 -rpcport=$${ZCASHD_RPCPORT} -rpcuser=$${ZCASHD_RPCUSER} -rpcpassword=$${ZCASHD_RPCPASSWORD} getblockchaininfo >/dev/null"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -44,6 +44,31 @@ services:
       - ./config/regtest/zallet.toml:/etc/zallet/zallet.toml:ro
       - ./config/regtest/zallet_identity.txt:/etc/zallet/identity.txt:ro
 
+  zcashd:
+    # Optional comparator for local compatibility checks. Keep it isolated
+    # from P2P in regtest. Activation heights default to config/regtest/zallet.toml
+    # but can be overridden for custom regtest runs.
+    command:
+      - -regtest
+      - -i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
+      - -listen=0
+      - -dnsseed=0
+      - -dns=0
+      - -connect=0
+      - -server=1
+      - -nuparams=5ba81b19:${ZCASHD_OVERWINTER_ACTIVATION_HEIGHT:-1}
+      - -nuparams=76b809bb:${ZCASHD_SAPLING_ACTIVATION_HEIGHT:-1}
+      - -nuparams=2bb40e60:${ZCASHD_BLOSSOM_ACTIVATION_HEIGHT:-1}
+      - -nuparams=f5b9230b:${ZCASHD_HEARTWOOD_ACTIVATION_HEIGHT:-1}
+      - -nuparams=e9ff75a6:${ZCASHD_CANOPY_ACTIVATION_HEIGHT:-1}
+      - -nuparams=c2d6d0b4:${ZCASHD_NU5_ACTIVATION_HEIGHT:-1}
+    healthcheck:
+      test: ["CMD-SHELL", "zcash-cli -regtest -rpcconnect=127.0.0.1 -rpcport=$${ZCASHD_RPCPORT} -rpcuser=$${ZCASHD_RPCUSER} -rpcpassword=$${ZCASHD_RPCPASSWORD} getblockchaininfo >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
   rpc-router:
     build:
       context: ./rpc-router

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,21 +150,29 @@ services:
     # Optional zcashd node. It is intentionally isolated from the
     # public P2P network unless the operator overrides the command.
     profiles: [zcashd]
-    image: ${ZCASHD_IMAGE:-electriccoinco/zcashd:latest}
-    # The official zcashd image currently publishes linux/amd64 only.
+    image: ${ZCASHD_IMAGE:-zodlinc/zcashd:v6.12.1}
+    # The default zcashd image currently publishes linux/amd64 only.
     platform: ${ZCASHD_DOCKER_PLATFORM:-linux/amd64}
     container_name: z3_zcashd
     restart: unless-stopped
     stop_grace_period: 30s
     <<: *common
-    user: "2001:2001"
+    user: "999:999"
     command:
+      - zcashd
+      - -conf=/dev/null
+      - -printtoconsole
       - -i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
       - -listen=0
       - -dnsseed=0
       - -dns=0
       - -connect=0
       - -server=1
+      - -rpcuser=${ZCASHD_RPCUSER:-zebra}
+      - -rpcpassword=${ZCASHD_RPCPASSWORD:-zebra}
+      - -rpcbind=0.0.0.0
+      - -rpcport=${ZCASHD_RPC_PORT:-38232}
+      - -rpcallowip=${ZCASHD_RPC_ALLOWIP:-0.0.0.0/0}
     environment:
       ZCASHD_RPCUSER: ${ZCASHD_RPCUSER:-zebra}
       ZCASHD_RPCPASSWORD: ${ZCASHD_RPCPASSWORD:-zebra}
@@ -172,14 +180,13 @@ services:
       ZCASHD_RPCPORT: ${ZCASHD_RPC_PORT:-38232}
       ZCASHD_ALLOWIP: ${ZCASHD_RPC_ALLOWIP:-0.0.0.0/0}
     volumes:
-      - ${Z3_ZCASHD_DATA_PATH:-zcashd_data}:/srv/zcashd/.zcash
-      - ${Z3_ZCASHD_PARAMS_PATH:-zcashd_params}:/srv/zcashd/.zcash-params
+      - ${Z3_ZCASHD_DATA_PATH:-zcashd_data}:/home/zcash/.zcash
     ports:
       - "${ZCASHD_HOST_RPC_BIND:-127.0.0.1}:${ZCASHD_HOST_RPC_PORT:-38232}:${ZCASHD_RPC_PORT:-38232}"
     networks:
       - z3_net
     healthcheck:
-      test: ["CMD-SHELL", "zcash-cli -rpcconnect=127.0.0.1 -rpcport=$${ZCASHD_RPCPORT} -rpcuser=$${ZCASHD_RPCUSER} -rpcpassword=$${ZCASHD_RPCPASSWORD} getblockchaininfo >/dev/null"]
+      test: ["CMD-SHELL", "zcash-cli -conf=/dev/null -rpcconnect=127.0.0.1 -rpcport=$${ZCASHD_RPCPORT} -rpcuser=$${ZCASHD_RPCUSER} -rpcpassword=$${ZCASHD_RPCPASSWORD} getblockchaininfo >/dev/null"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -302,7 +309,6 @@ services:
 volumes:
   zebra_data:
   zcashd_data:
-  zcashd_params:
   zaino_data:
   zallet_data:
   shared_cookie_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-common: &common
 
 services:
   zebra:
-    image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.0}
+    image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.1}
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     build:
       context: ./zebra

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,45 @@ services:
       - z3_net
     # No healthcheck: distroless image has no shell/curl
 
+  zcashd:
+    # Optional zcashd node. It is intentionally isolated from the
+    # public P2P network unless the operator overrides the command.
+    profiles: [zcashd]
+    image: ${ZCASHD_IMAGE:-electriccoinco/zcashd:latest}
+    # The official zcashd image currently publishes linux/amd64 only.
+    platform: ${ZCASHD_DOCKER_PLATFORM:-linux/amd64}
+    container_name: z3_zcashd
+    restart: unless-stopped
+    stop_grace_period: 30s
+    <<: *common
+    user: "2001:2001"
+    command:
+      - -i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
+      - -listen=0
+      - -dnsseed=0
+      - -dns=0
+      - -connect=0
+      - -server=1
+    environment:
+      ZCASHD_RPCUSER: ${ZCASHD_RPCUSER:-zebra}
+      ZCASHD_RPCPASSWORD: ${ZCASHD_RPCPASSWORD:-zebra}
+      ZCASHD_RPCBIND: 0.0.0.0
+      ZCASHD_RPCPORT: ${ZCASHD_RPC_PORT:-38232}
+      ZCASHD_ALLOWIP: ${ZCASHD_RPC_ALLOWIP:-0.0.0.0/0}
+    volumes:
+      - ${Z3_ZCASHD_DATA_PATH:-zcashd_data}:/srv/zcashd/.zcash
+      - ${Z3_ZCASHD_PARAMS_PATH:-zcashd_params}:/srv/zcashd/.zcash-params
+    ports:
+      - "${ZCASHD_HOST_RPC_BIND:-127.0.0.1}:${ZCASHD_HOST_RPC_PORT:-38232}:${ZCASHD_RPC_PORT:-38232}"
+    networks:
+      - z3_net
+    healthcheck:
+      test: ["CMD-SHELL", "zcash-cli -rpcconnect=127.0.0.1 -rpcport=$${ZCASHD_RPCPORT} -rpcuser=$${ZCASHD_RPCUSER} -rpcpassword=$${ZCASHD_RPCPASSWORD} getblockchaininfo >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
   # =============================================================================
   # Monitoring Stack (enabled with --profile monitoring)
   # =============================================================================
@@ -262,6 +301,8 @@ services:
 
 volumes:
   zebra_data:
+  zcashd_data:
+  zcashd_params:
   zaino_data:
   zallet_data:
   shared_cookie_volume:

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -23,7 +23,7 @@ The core principle: **`docker-compose.yml` is self-sufficient**. Every variable 
 Every variable reference in `docker-compose.yml` includes a default value:
 
 ```yaml
-image: ${ZEBRA_IMAGE:-zfnd/zebra:4.2.0}
+image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.1}
 environment:
   ZEBRA_NETWORK__NETWORK: ${NETWORK_NAME:-Mainnet}
 volumes:
@@ -198,7 +198,7 @@ Without `max-size` and `max-file`, Docker's default `json-file` log driver grows
 All service images are overridable via environment variables:
 
 ```yaml
-image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.0}
+image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.1}
 image: ${ZAINO_IMAGE:-ghcr.io/zcashfoundation/zaino:sha-83e41d7}
 image: ${ZALLET_IMAGE:-electriccoinco/zallet:v0.1.0-alpha.3}
 image: ${ZCASHD_IMAGE:-electriccoinco/zcashd:latest}

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -201,7 +201,7 @@ All service images are overridable via environment variables:
 image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.1}
 image: ${ZAINO_IMAGE:-ghcr.io/zcashfoundation/zaino:sha-83e41d7}
 image: ${ZALLET_IMAGE:-electriccoinco/zallet:v0.1.0-alpha.3}
-image: ${ZCASHD_IMAGE:-electriccoinco/zcashd:latest}
+image: ${ZCASHD_IMAGE:-zodlinc/zcashd:v6.12.1}
 ```
 
 This allows operators to:

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -5,7 +5,7 @@ This document explains the architectural decisions, patterns, and modern Docker 
 ## Overview
 
 ```text
-docker-compose.yml              Base stack (Zebra + Zaino + Zallet + monitoring)
+docker-compose.yml              Base stack (Zebra + Zaino + Zallet + optional profiles)
 docker-compose.regtest.yml      Regtest overlay (structural differences only)
 .env.example                    Reference for all overridable variables
 .env                            User overrides (gitignored, optional)
@@ -198,9 +198,10 @@ Without `max-size` and `max-file`, Docker's default `json-file` log driver grows
 All service images are overridable via environment variables:
 
 ```yaml
-image: ${ZEBRA_IMAGE:-zfnd/zebra:4.2.0}
-image: ${ZAINO_IMAGE:-ghcr.io/zcashfoundation/zaino:sha-0164cab}
+image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.0}
+image: ${ZAINO_IMAGE:-ghcr.io/zcashfoundation/zaino:sha-83e41d7}
 image: ${ZALLET_IMAGE:-electriccoinco/zallet:v0.1.0-alpha.3}
+image: ${ZCASHD_IMAGE:-electriccoinco/zcashd:latest}
 ```
 
 This allows operators to:

--- a/docs/regtest.md
+++ b/docs/regtest.md
@@ -62,7 +62,7 @@ For local compatibility checks against zcashd, start the profiled zcashd service
 docker compose --env-file .env.regtest --profile zcashd up -d zcashd
 ```
 
-The regtest overlay starts zcashd with public P2P disabled (`-listen=0 -connect=0`) and, by default, the same NU activation heights used by Zallet. It uses separate Docker volumes (`zcashd_data`, `zcashd_params`) and default RPC credentials `zebra` / `zebra`. See the [README platform section](../README.md#platform-configuration-arm64) for arm64 notes.
+The regtest overlay starts zcashd with public P2P disabled (`-listen=0 -connect=0`) and, by default, the same NU activation heights used by Zallet. It uses a separate Docker volume (`zcashd_data`) and default RPC credentials `zebra` / `zebra`. See the [README platform section](../README.md#platform-configuration-arm64) for arm64 notes.
 
 For comparator runs that need a specific upgrade era, override the zcashd activation heights and use a separate data volume:
 

--- a/docs/regtest.md
+++ b/docs/regtest.md
@@ -52,6 +52,27 @@ Zebra, Zaino, and Zallet use pre-built images. The rpc-router builds from source
 | Zaino gRPC | https://localhost:8137 | lightwalletd-compatible gRPC (TLS) |
 | Zebra RPC | http://localhost:18232 | Direct Zebra JSON-RPC |
 | Zallet RPC | http://localhost:28232 | Direct Zallet JSON-RPC |
+| zcashd RPC | http://localhost:38232 | Optional zcashd comparator (`--profile zcashd`) |
+
+## Optional zcashd comparator
+
+For local compatibility checks against zcashd, start the profiled zcashd service:
+
+```bash
+docker compose --env-file .env.regtest --profile zcashd up -d zcashd
+```
+
+The regtest overlay starts zcashd with public P2P disabled (`-listen=0 -connect=0`) and, by default, the same NU activation heights used by Zallet. It uses separate Docker volumes (`zcashd_data`, `zcashd_params`) and default RPC credentials `zebra` / `zebra`. See the [README platform section](../README.md#platform-configuration-arm64) for arm64 notes.
+
+For comparator runs that need a specific upgrade era, override the zcashd activation heights and use a separate data volume:
+
+```bash
+Z3_ZCASHD_DATA_PATH=./.tmp/zcashd-canopy-data \
+ZCASHD_NU5_ACTIVATION_HEIGHT=100 \
+docker compose --env-file .env.regtest --profile zcashd up -d --force-recreate zcashd
+```
+
+This keeps the default Z3 regtest state separate from comparator state and allows V4/Canopy fixtures before NU5 activation.
 
 ## Test routing
 
@@ -159,4 +180,5 @@ The port (9999) must match the Prometheus scrape target configured in `observabi
 - Zallet uses regtest nuparams activating all upgrades at block 1
 - Zaino uses username/password auth in regtest (not cookie auth)
 - Zaino gRPC uses TLS with the same self-signed certificate as mainnet/testnet
+- zcashd is optional and only starts when the `zcashd` profile is enabled
 - The rpc-router source is in `rpc-router/`; it is built automatically on first `docker compose up`

--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -6,12 +6,13 @@
 # Usage:
 #   ./fix-permissions.sh <service> <directory_path>
 #
-# Services: zebra, zaino, zallet, cookie
+# Services: zebra, zaino, zallet, zcashd, cookie
 #
 # Examples:
 #   ./fix-permissions.sh zebra /mnt/ssd/zebra-state
 #   ./fix-permissions.sh zaino /home/user/data/zaino
 #   ./fix-permissions.sh zallet ~/Documents/zallet-data
+#   ./fix-permissions.sh zcashd /mnt/ssd/zcashd-data
 #   ./fix-permissions.sh cookie /var/lib/z3/cookies
 #
 
@@ -30,6 +31,8 @@ ZAINO_UID=1000
 ZAINO_GID=1000
 ZALLET_UID=65532
 ZALLET_GID=65532
+ZCASHD_UID=999
+ZCASHD_GID=999
 
 # Show usage
 usage() {
@@ -39,12 +42,14 @@ usage() {
     echo "  zebra   - Zebra blockchain state (UID:GID 10001:10001, perms 700)"
     echo "  zaino   - Zaino indexer data (UID:GID 1000:1000, perms 700)"
     echo "  zallet  - Zallet wallet data (UID:GID 65532:65532, perms 700)"
+    echo "  zcashd  - Optional zcashd comparator data (UID:GID 999:999, perms 700)"
     echo "  cookie  - Shared cookie directory (UID:GID 10001:10001, perms 750)"
     echo ""
     echo "Examples:"
     echo "  $0 zebra /mnt/ssd/zebra-state"
     echo "  $0 zaino /home/user/data/zaino"
     echo "  $0 zallet ~/Documents/zallet-data"
+    echo "  $0 zcashd /mnt/ssd/zcashd-data"
     exit 1
 }
 
@@ -71,6 +76,11 @@ case "$SERVICE" in
     zallet)
         OWNER_UID=$ZALLET_UID
         OWNER_GID=$ZALLET_GID
+        PERMS=700
+        ;;
+    zcashd)
+        OWNER_UID=$ZCASHD_UID
+        OWNER_GID=$ZCASHD_GID
         PERMS=700
         ;;
     cookie)
@@ -130,6 +140,9 @@ case "$SERVICE" in
         ;;
     zallet)
         echo "  Z3_ZALLET_DATA_PATH=${DIR_PATH}"
+        ;;
+    zcashd)
+        echo "  Z3_ZCASHD_DATA_PATH=${DIR_PATH}"
         ;;
     cookie)
         echo "  Z3_COOKIE_PATH=${DIR_PATH}"


### PR DESCRIPTION
## Summary

Adds an opt-in `zcashd` Compose profile for local comparison checks without changing the default Z3 stack. The service uses the official `electriccoinco/zcashd:latest` image, keeps public P2P disabled by default, exposes RPC on localhost, and stores state in separate volumes.

The regtest overlay adds matching activation-height overrides so operators can run isolated regtest scenarios with a separate data path. Documentation and `.env.example` now include the profile, ports, data paths, and arm64 platform guidance.

## Notes

The official `electriccoinco/zcashd:latest` image currently publishes a `linux/amd64` runtime image. The compose profile therefore defaults `ZCASHD_DOCKER_PLATFORM` to `linux/amd64`, which Docker Desktop can run through emulation on Apple Silicon.

## AI Disclosure

OpenAI Codex assisted with the Compose changes, documentation edits, and local validation commands.