### PR TITLE
ci: switch push triggers from dev to main

### DIFF
--- a/.github/workflows/build-z3-images.yaml
+++ b/.github/workflows/build-z3-images.yaml
@@ -58,6 +58,7 @@ jobs:
       rust_backtrace: full
       rust_lib_backtrace: full
       rust_log: info
+      read_rust_version: true
 
   build-zallet:
     name: Build zallet Docker

--- a/.github/workflows/build-z3-images.yaml
+++ b/.github/workflows/build-z3-images.yaml
@@ -14,7 +14,7 @@ on:
         default: false
   push:
     branches:
-      - dev
+      - main
     paths:
       - '.github/workflows/build-z3-images.yaml'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   pull_request:
   push:
-    branches: [dev]
+    branches: [main]
 
 permissions: {}
 

--- a/.github/workflows/sub-build-docker-image.yaml
+++ b/.github/workflows/sub-build-docker-image.yaml
@@ -88,10 +88,13 @@ jobs:
       - name: Read RUST_VERSION from rust-toolchain.toml
         if: ${{ inputs.read_rust_version }}
         id: rust_version
+        env:
+          UPSTREAM_REPO: ${{ inputs.repository }}
+          UPSTREAM_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           if [[ ! -f rust-toolchain.toml ]]; then
-            echo "rust-toolchain.toml not found in ${{ inputs.repository }}@${{ inputs.ref }}" >&2
+            echo "rust-toolchain.toml not found in ${UPSTREAM_REPO}@${UPSTREAM_REF}" >&2
             exit 1
           fi
           channel=$(grep -E '^[[:space:]]*channel[[:space:]]*=' rust-toolchain.toml \

--- a/.github/workflows/sub-build-docker-image.yaml
+++ b/.github/workflows/sub-build-docker-image.yaml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: false
+      read_rust_version:
+        description: "Read RUST_VERSION from rust-toolchain.toml in the checked-out upstream repo and pass it as a build-arg"
+        required: false
+        type: boolean
+        default: false
 
     outputs:
       image_digest:
@@ -79,6 +84,28 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           persist-credentials: false
+
+      - name: Read RUST_VERSION from rust-toolchain.toml
+        if: ${{ inputs.read_rust_version }}
+        id: rust_version
+        run: |
+          set -euo pipefail
+          if [[ ! -f rust-toolchain.toml ]]; then
+            echo "rust-toolchain.toml not found in ${{ inputs.repository }}@${{ inputs.ref }}" >&2
+            exit 1
+          fi
+          channel=$(grep -E '^[[:space:]]*channel[[:space:]]*=' rust-toolchain.toml \
+            | head -n1 \
+            | sed -E 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          if [[ -z "$channel" ]]; then
+            echo "no [toolchain].channel found in rust-toolchain.toml" >&2
+            exit 1
+          fi
+          if [[ ! "$channel" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "channel '$channel' is not a concrete numeric version (x.y or x.y.z)" >&2
+            exit 1
+          fi
+          echo "rust_version=$channel" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Z3
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -139,6 +166,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
+            ${{ inputs.read_rust_version && format('RUST_VERSION={0}', steps.rust_version.outputs.rust_version) || '' }}
           push: true
           # It's recommended to build images with max-level provenance attestations
           # https://docs.docker.com/build/ci/github-actions/attestations/

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -2,7 +2,7 @@ name: GitHub Actions security analysis
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     paths:
       - '.github/workflows/**'
   pull_request:


### PR DESCRIPTION
## Summary
- Update `branches:` filters on push triggers from `dev` → `main` in the three workflows that still pin the old default: `ci.yaml`, `zizmor.yaml`, `build-z3-images.yaml`.
- Closes the workflow-side follow-up to #26 (default branch rename `dev` → `main`).

## Why this is needed
The repo default was just renamed from `dev` to `main`. These three workflows have `push` triggers pinned to a specific branch, so without this change they would no longer fire on pushes to the new default.

PR-triggered jobs were unaffected (the `pull_request:` triggers have no branch filter).

The `ref: 'dev'` in `build-z3-images.yaml` is intentionally left alone — it refers to the upstream `zingolabs/zaino` branch, not this repo. Likewise the `environment: ... 'dev'` in `sub-build-docker-image.yaml` is a GitHub Environment name, not a branch.

## Test plan
- [ ] After merge, push a no-op or this PR's merge commit to `main` and confirm `CI`, `GitHub Actions security analysis`, and (if touched) `Build Z3 images` all trigger.
- [ ] Confirm `gh pr list --base main` shows the previously-`dev`-based open PRs (they should have been auto-retargeted by GitHub's branch rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)