### PR TITLE
ci: add cargo test job for rpc-router

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,3 +125,20 @@ jobs:
           docker compose --env-file .env.regtest --profile zcashd logs zcashd --tail 50 2>&1 || true
           echo "=== Container status ==="
           docker compose --env-file .env.regtest --profile zcashd ps 2>&1 || true
+
+  rpc-router-tests:
+    name: rpc-router cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.85 --profile minimal --no-self-update
+          rustup default 1.85
+
+      - name: cargo test
+        working-directory: rpc-router
+        run: cargo test --locked --all-targets


### PR DESCRIPTION
## Summary

- Add a `rpc-router cargo test` CI job that runs `cargo test --locked --all-targets` in `rpc-router/` on Rust 1.85.
- Closes a gap in the existing CI: the `smoke-test` job only builds the binary (`cargo build --release --bin rpc-router`) and validates the docker compose regtest stack — it never runs `rpc-router/src/unit_tests.rs` (13 tests) or `rpc-router/src/integration_tests.rs` (7 tests).
- Motivation: open Dependabot PRs #34 (rustls-webpki) and #38 (openssl) are lockfile-only bumps under `rpc-router/Cargo.lock` for transitive deps. With the existing CI they only get build-time signal. Landing this job first means those PRs (once rebased) get actual test signal before merging.
- Toolchain pinned to 1.85 to match `rpc-router/Dockerfile` (`cargo-chef:latest-rust-1.85`). `--locked` forces resolution against the exact `Cargo.lock` in the PR, which is the whole point for dependency-bump validation.
- No third-party caching action in this first cut — keeps the surface small for zizmor; the crate is tiny and tests run in well under a second locally.

## Test plan

- [x] Local: `cargo test --manifest-path rpc-router/Cargo.toml --locked --all-targets` — 20/20 passing on this branch (rust 1.95 locally; CI uses 1.85, lockfile is v4 which both support).
- [x] CI: new `rpc-router cargo test` check appears and passes on this PR.
- [x] Existing `Service smoke tests` check still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)