### PR TITLE
chore: bump default zebra to latest (v5.0.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@
 # =============================================================================
 # Image Overrides (defaults are pinned versions in docker-compose.yml)
 # =============================================================================
-# ZEBRA_IMAGE=zfnd/zebra:4.3.1
+# ZEBRA_IMAGE=zfnd/zebra:latest
 # ZAINO_IMAGE=ghcr.io/zcashfoundation/zaino:sha-83e41d7
 # ZALLET_IMAGE=electriccoinco/zallet:v0.1.0-alpha.3
 # ZCASHD_IMAGE=zodlinc/zcashd:v6.12.1

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ All images can be overridden via environment variables (`ZEBRA_IMAGE`, `ZAINO_IM
 
 | Service | Default Image | Source |
 |---------|---------------|--------|
-| Zebra | `zfnd/zebra:4.3.1` | [ZcashFoundation/zebra](https://github.com/ZcashFoundation/zebra) |
+| Zebra | `zfnd/zebra:latest` | [ZcashFoundation/zebra](https://github.com/ZcashFoundation/zebra) |
 | Zaino | `ghcr.io/zcashfoundation/zaino:sha-83e41d7` | [zingolabs/zaino](https://github.com/zingolabs/zaino) |
 | Zallet | `electriccoinco/zallet:v0.1.0-alpha.3` | [zcash/wallet](https://github.com/zcash/wallet) |
 | zcashd | `zodlinc/zcashd:v6.12.1` | [zcash/zcash](https://github.com/zcash/zcash) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-common: &common
 
 services:
   zebra:
-    image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.1}
+    image: ${ZEBRA_IMAGE:-zfnd/zebra:latest}
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     build:
       context: ./zebra

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -23,7 +23,7 @@ The core principle: **`docker-compose.yml` is self-sufficient**. Every variable 
 Every variable reference in `docker-compose.yml` includes a default value:
 
 ```yaml
-image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.1}
+image: ${ZEBRA_IMAGE:-zfnd/zebra:latest}
 environment:
   ZEBRA_NETWORK__NETWORK: ${NETWORK_NAME:-Mainnet}
 volumes:
@@ -198,7 +198,7 @@ Without `max-size` and `max-file`, Docker's default `json-file` log driver grows
 All service images are overridable via environment variables:
 
 ```yaml
-image: ${ZEBRA_IMAGE:-zfnd/zebra:4.3.1}
+image: ${ZEBRA_IMAGE:-zfnd/zebra:latest}
 image: ${ZAINO_IMAGE:-ghcr.io/zcashfoundation/zaino:sha-83e41d7}
 image: ${ZALLET_IMAGE:-electriccoinco/zallet:v0.1.0-alpha.3}
 image: ${ZCASHD_IMAGE:-zodlinc/zcashd:v6.12.1}


### PR DESCRIPTION
## Summary

- Switch the docker-compose default for the zebra service from `zfnd/zebra:4.3.1` to `zfnd/zebra:latest`, so fresh stacks track upstream Zebra releases without requiring a `.env` override. At time of writing, `latest` resolves to v5.0.0.
- Mirror the change in `.env.example`, the README "Default Image" table, and the `docs/docker-architecture.md` illustrative snippets so the docs match the runtime default.
- Bump the `zebra/` git submodule pointer to the `v5.0.0` tag so the build-from-source path (`docker compose build`) lines up with the new default image.

Operators who need reproducibility can still pin via `ZEBRA_IMAGE=zfnd/zebra:<version>` in `.env` — the README retains an example.

## Known follow-up (not in this PR)

The `zaino` service is pinned to an image annotated as "Zebra 4.3.0 compatible" (see comment at `docker-compose.yml:69`). With Zebra v5.0.0 as the default, zaino may surface RPC-compat issues. Leaving zaino untouched here to keep this change focused; a Zebra-5-compatible zaino bump can land separately.

## Test plan

- [x] `docker compose config | grep zebra` resolves to `zfnd/zebra:latest`
- [x] `docker compose pull zebra` succeeds (confirms the `latest` tag is reachable on Docker Hub)
- [x] `docker compose up -d zebra` and `/healthy` returns 200 after start-up
- [ ] `docker compose up -d` boots the full stack; check `docker compose logs zaino --tail=50` for the compat risk flagged above
- [x] `git -C zebra describe --tags` reports `v5.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)