### PR TITLE
docs: document Zebra latest image override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@
 
 # Image pins. Defaults live in docker-compose.yml as ${VAR:-tag} fallbacks;
 # override per pin here to test a pre-release or pin a digest.
+# To opt into a moving tag such as zfnd/zebra:latest, see docs/faq.md.
 # Z3_ZEBRA_IMAGE=zfnd/zebra:5.0.0
 # Z3_ZAINO_IMAGE=zingodevops/zainod:0.4.0-rc.2
 # Z3_ZALLET_IMAGE=zodlinc/zallet:v0.1.0-alpha.4

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Z3 ships production-shaped defaults, but a few choices are yours to make before 
 - **Tune the host network (Linux).** On a busy mainnet node, default kernel TCP buffer and connection-backlog limits can cap Zebra's peer throughput. See [Zebra's TCP tuning notes](https://github.com/ZcashFoundation/zebra/pull/10513) for the `sysctl` values worth raising.
 - **Bound resources on a shared host.** No CPU or memory limits are set by default: right for a dedicated node, easy to get wrong on a shared box. Add `deploy.resources.limits` in an override file if you need them.
 
-Z3 ships safe defaults: pinned image versions (no surprise upgrades), non-root containers with Linux capabilities dropped, health checks that hold the wallet back until the node is synced, and automatic restart. Upgrades stay deliberate: bump the version pin in a reviewed change, or set `Z3_<SERVICE>_IMAGE`.
+Z3 ships safe defaults: pinned image versions (no surprise upgrades), non-root containers with Linux capabilities dropped, health checks that hold the wallet back until the node is synced, and automatic restart. Upgrades stay deliberate: bump the version pin in a reviewed change, or set `Z3_<SERVICE>_IMAGE`. Operators who prefer to track a moving image tag, such as `zfnd/zebra:latest`, can do that without editing the tracked stack; see the [FAQ](docs/faq.md#q-how-do-i-track-zebras-latest-image-without-updating-z3).
 
 ### Monitoring
 
@@ -306,7 +306,7 @@ z3 sets the service-internal vars (`ZEBRA_RPC__LISTEN_ADDR`, `ZAINO_VALIDATOR_SE
 Z3_ZEBRA_RUST_LOG=debug
 Z3_ZAINO_RUST_LOG=debug
 
-# Pin a different image version
+# Pin a different image version, or use zfnd/zebra:latest to track Zebra releases
 Z3_ZEBRA_IMAGE=zfnd/zebra:5.0.0
 
 # Move chain state to an external SSD

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -242,7 +242,7 @@ All service images are overridable. Compose references each image as `${Z3_<SERV
 - Use a private registry mirror in air-gapped environments.
 - Run CI with custom-built images via shell variables.
 
-Tags are pinned, never floating (`:latest`). On a consensus-critical node platform a silent major bump on the next `pull` or recreate could fork the operator off the network, so upgrades are deliberate: bump the inline default in a reviewed change, set `Z3_<SERVICE>_IMAGE` to move a single service, or let Renovate (`renovate.json`) raise an auditable bump PR. Dependabot stays scoped to GitHub Actions because it cannot parse the `${VAR:-tag}` default form.
+Tracked defaults are pinned, never floating (`:latest`). On a consensus-critical node platform a silent major bump on the next `pull` or recreate could fork the operator off the network, so default upgrades are deliberate: bump the inline default in a reviewed change, set `Z3_<SERVICE>_IMAGE` to move a single service, or let Renovate (`renovate.json`) raise an auditable bump PR. Operators who intentionally want a moving tag can set `Z3_<SERVICE>_IMAGE` locally; the [FAQ](faq.md#q-how-do-i-track-zebras-latest-image-without-updating-z3) shows the Zebra `latest` workflow. Dependabot stays scoped to GitHub Actions because it cannot parse the `${VAR:-tag}` default form.
 
 The `Z3_*_IMAGE` prefix marks these as part of the public contract; `z3-contract.yaml` lists the env-var schema in full.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -96,6 +96,30 @@ Keep the limit generous on the service you want to win contention (Zebra), tight
 
 ---
 
+### Q: How do I track Zebra's latest image without updating Z3?
+
+Z3's checked-in defaults stay pinned so a `docker compose pull` cannot silently change the node version for every operator. If you prefer fewer Z3 stack updates and accept a moving Zebra image, set the image override in your operator-local `.env`:
+
+```bash
+Z3_ZEBRA_IMAGE=zfnd/zebra:latest
+```
+
+Then pull before recreating Zebra. Docker does not fetch a newer image just because the tag is named `latest`; run `pull` first or use `up --pull always`. When you use the documented `--env-file .env.<network>` commands, pass `.env` after the network file so the override is loaded:
+
+```bash
+docker compose --env-file .env.mainnet --env-file .env pull zebra
+docker compose --env-file .env.mainnet --env-file .env up -d zebra
+
+# Equivalent one-command form:
+docker compose --env-file .env.mainnet --env-file .env up -d --pull always zebra
+```
+
+For testnet or regtest, replace `.env.mainnet` with `.env.testnet` or `.env.regtest`. If you run mainnet without `--env-file`, Compose auto-loads `.env`, so `docker compose up -d --pull always zebra` is enough.
+
+The same override pattern works for other services through `Z3_ZAINO_IMAGE` and `Z3_ZALLET_IMAGE`, but do not switch those to a moving tag unless you have checked the tag keeps the variant and platform support Z3 expects.
+
+---
+
 ## For developers and testers
 
 ### Q: How do per-network compose overrides work?


### PR DESCRIPTION
## Summary

- Document how operators can opt into `zfnd/zebra:latest` through `Z3_ZEBRA_IMAGE` without changing the tracked stack defaults.
- Add FAQ commands for loading the local `.env` after the per-network env file and for using `up --pull always`.
- Clarify that tracked image defaults stay pinned while local moving-tag overrides are supported.