### PR TITLE
refactor: default stack is Zebra + Zallet, Zaino behind an indexer profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,22 +21,22 @@
 # Image pins. Defaults live in docker-compose.yml as ${VAR:-tag} fallbacks;
 # override per pin here to test a pre-release or pin a digest.
 # To opt into a moving tag such as zfnd/zebra:latest, see docs/faq.md.
-# Z3_ZEBRA_IMAGE=zfnd/zebra:5.0.0
-# Z3_ZAINO_IMAGE=zingodevops/zainod:0.4.0-rc.2
-# Z3_ZALLET_IMAGE=zodlinc/zallet:v0.1.0-alpha.4
+# Z3_ZEBRA_IMAGE=zfnd/zebra:6.0.0-rc.0
+# Z3_ZAINO_IMAGE=zingodevops/zainod:0.5.1-no-tls   # indexer profile (--profile indexer)
+# Z3_ZALLET_IMAGE=zodlinc/zallet:v0.1.0-alpha.4@sha256:3097751a2502857294d7031a360023834b53a6ebd31ed4520f6cd3a148074dbf
 # Z3_ZEBRA_BUILD_FEATURES=default-release-binaries
 
-# Platform pin. Zebra is multi-arch and selects the host arch automatically.
-# Zaino and Zallet's zaino-backed binary are pinned to amd64 in compose because
-# their upstream images publish the needed binaries for amd64 only; setting
-# DOCKER_PLATFORM=linux/arm64 with the opt-in build overlay
-# (docker-compose.build.yml) builds them native arm64.
+# Platform pin. Zebra and Zallet are multi-arch and select the host arch
+# automatically. Zaino is pinned to amd64 in compose because its upstream image
+# publishes amd64 only; setting DOCKER_PLATFORM=linux/arm64 with the opt-in
+# build overlay (docker-compose.build.yml) builds it native arm64.
 # DOCKER_PLATFORM=linux/arm64
 
 # Host ports (mainnet defaults; .env.testnet and .env.regtest override them)
 # Z3_ZEBRA_HOST_RPC_PORT=8232
 # Z3_ZEBRA_HOST_P2P_PORT=8233
 # Z3_ZEBRA_HOST_HEALTH_PORT=8080
+# Zaino indexer ports (published only with --profile indexer)
 # Z3_ZAINO_HOST_GRPC_PORT=8137
 # Z3_ZAINO_HOST_JSON_RPC_PORT=8237
 # Z3_ZALLET_HOST_RPC_PORT=28232

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,9 @@ jobs:
           docker compose --env-file .env.mainnet --profile monitoring config --quiet
           docker compose --env-file .env.testnet --profile monitoring config --quiet
           docker compose --env-file .env.regtest --profile monitoring config --quiet
+          docker compose --env-file .env.mainnet --profile indexer config --quiet
+          docker compose --env-file .env.testnet --profile indexer config --quiet
+          docker compose --env-file .env.regtest --profile indexer config --quiet
 
       - name: Install Python deps (contract parser + JSON Schema validator)
         run: python3 -m pip install --quiet pyyaml jsonschema
@@ -158,31 +161,13 @@ jobs:
             -d '{"jsonrpc":"2.0","method":"getblockchaininfo","params":[],"id":1}' \
             http://127.0.0.1:29232 | jq .
 
-      - name: Mine block 1 (required for Zaino sync)
+      - name: Mine the activation blocks
+        # config/regtest activates NU5 at height 2; mine two blocks so the
+        # network is past activation before wallet init.
         run: |
           curl -sf -u zebra:zebra -X POST -H "Content-Type: application/json" \
-            -d '{"jsonrpc":"2.0","method":"generate","params":[1],"id":1}' \
+            -d '{"jsonrpc":"2.0","method":"generate","params":[2],"id":1}' \
             http://127.0.0.1:29232 | jq .
-
-      - name: Start Zaino and verify JSON-RPC proxy
-        run: |
-          docker compose --env-file .env.regtest up -d zaino
-          echo "Waiting for Zaino JSON-RPC on host port 28237..."
-          for i in $(seq 1 30); do
-            if RESULT=$(curl -sf -X POST -H "Content-Type: application/json" \
-              -d '{"jsonrpc":"2.0","method":"getblockchaininfo","params":[],"id":1}' \
-              http://127.0.0.1:28237 2>/dev/null); then
-              echo "Zaino is ready"
-              echo "$RESULT" | jq .
-              break
-            fi
-            if [ "$i" -eq 30 ]; then
-              echo "Zaino failed to start"
-              docker compose --env-file .env.regtest logs zaino --tail 20
-              exit 1
-            fi
-            sleep 2
-          done
 
       - name: Verify Zallet accepts compose command
         run: docker compose --env-file .env.regtest run --rm --no-deps zallet --help
@@ -201,6 +186,39 @@ jobs:
           MODE="$(docker run --rm -v z3-regtest-zallet:/d busybox stat -c '%a' /d/identity.txt)"
           test "$MODE" = "600"
           echo "identity.txt present in z3-regtest-zallet volume, mode $MODE"
+
+      - name: Initialize the wallet and generate a mnemonic
+        run: |
+          docker compose --env-file .env.regtest run --rm zallet \
+            --datadir /var/lib/zallet --config /etc/zallet/zallet.toml \
+            init-wallet-encryption
+          docker compose --env-file .env.regtest run --rm zallet \
+            --datadir /var/lib/zallet --config /etc/zallet/zallet.toml \
+            generate-mnemonic
+
+      - name: Start Zallet and rpc-router, verify wallet RPC
+        run: |
+          docker compose --env-file .env.regtest up -d zallet rpc-router
+          echo "Waiting for Zallet wallet RPC on host port 50232..."
+          for i in $(seq 1 30); do
+            if RESULT=$(curl -sf -u zebra:zebra -X POST -H "Content-Type: application/json" \
+              -d '{"jsonrpc":"2.0","method":"getwalletinfo","params":[],"id":1}' \
+              http://127.0.0.1:50232 2>/dev/null); then
+              echo "Zallet wallet RPC is ready"
+              echo "$RESULT" | jq .
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Zallet wallet RPC never responded"
+              docker compose --env-file .env.regtest logs zallet rpc-router --tail 50
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Asserting rpc-router proxies chain RPCs..."
+          curl -sf -u zebra:zebra -X POST -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"getblockchaininfo","params":[],"id":1}' \
+            http://127.0.0.1:8181 | jq .result.blocks
 
       - name: Assert Zallet config is readable by the compose user
         # Guards the config-readability contract at the same UID/GID declared
@@ -223,7 +241,7 @@ jobs:
       - name: Verify the external network is attachable
         run: |
           docker run --rm --network "$EXTERNAL_NETWORK" alpine \
-            sh -c 'apk add --no-cache bind-tools >/dev/null 2>&1 && nslookup zebra && nslookup zaino'
+            sh -c 'apk add --no-cache bind-tools >/dev/null 2>&1 && nslookup zebra && nslookup zallet'
 
       - name: Collect logs on failure
         if: failure()
@@ -232,8 +250,14 @@ jobs:
           docker compose --env-file .env.regtest ps 2>&1 || true
           echo "=== Zebra logs ==="
           docker compose --env-file .env.regtest logs zebra --tail 50 2>&1 || true
-          echo "=== Zaino logs ==="
-          docker compose --env-file .env.regtest logs zaino --tail 50 2>&1 || true
+          echo "=== Zallet logs ==="
+          docker compose --env-file .env.regtest logs zallet --tail 50 2>&1 || true
+          echo "=== rpc-router logs ==="
+          docker compose --env-file .env.regtest logs rpc-router --tail 50 2>&1 || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose --env-file .env.regtest --profile "*" down -v --remove-orphans 2>&1 || true
 
   cookie-permission-smoke:
     # Regtest disables cookie auth, so the regtest smoke job does not exercise
@@ -288,7 +312,7 @@ jobs:
 
       - name: Tear down
         if: always()
-        run: docker compose --env-file .env.testnet down -v --remove-orphans 2>&1 || true
+        run: docker compose --env-file .env.testnet --profile "*" down -v --remove-orphans 2>&1 || true
 
   rpc-router-tests:
     name: rpc-router cargo test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Z3: a Zcash node platform
 
-Z3 runs **Zebra** (full node), **Zaino** (indexer), and **Zallet** (wallet) together with Docker Compose, on mainnet, testnet, or a local regtest network.
+Z3 runs **Zebra** (full node) and **Zallet** (wallet) together with Docker Compose, on mainnet, testnet, or a local regtest network. An optional **Zaino** indexer adds a lightwalletd-compatible gRPC endpoint behind the `indexer` profile.
 
 Two kinds of people use Z3, and this README is split for them:
 
@@ -31,7 +31,7 @@ All three can run at once on one host; each gets its own ports and volumes. New 
 
 Each network has a one-time setup step and a start step.
 
-**Mainnet (production).** Zebra must sync the whole chain before Zaino and Zallet can serve clients, so the boot is two-phase: start Zebra, wait for the sync, then start the rest.
+**Mainnet (production).** Zebra must sync the whole chain before Zallet can serve clients, so the boot is two-phase: start Zebra, wait for the sync, then start the rest.
 
 ```bash
 git clone https://github.com/ZcashFoundation/z3 && cd z3
@@ -43,14 +43,14 @@ git clone https://github.com/ZcashFoundation/z3 && cd z3
 docker compose --env-file .env.mainnet up -d zebra
 ./scripts/check-zebra-readiness.sh
 
-# 3. Start Zaino + Zallet once Zebra is synced.
+# 3. Start Zallet once Zebra is synced.
 docker compose --env-file .env.mainnet up -d
 ```
 
 Images are pulled automatically; no build step or source checkout is needed.
 
 > [!IMPORTANT]
-> Running step 3 before Zebra reaches `/ready` makes Zaino and Zallet restart-loop until the sync catches up. The poller in step 2 exits only when Zebra is synced.
+> Running step 3 before Zebra reaches `/ready` makes Zallet restart-loop until the sync catches up. The poller in step 2 exits only when Zebra is synced.
 
 Your edits to the per-network config under `config/<network>/` stay local and survive `git pull`.
 
@@ -79,7 +79,7 @@ Each network keeps its chain state in a Docker named volume called `z3-<network>
 - **Find the path:** `docker volume inspect z3-mainnet-chain -f '{{.Mountpoint}}'`
 - **Put it on another disk:** set `Z3_CHAIN_DATA_PATH=/mnt/ssd/zebra-state` and run `./scripts/fix-permissions.sh zebra /mnt/ssd/zebra-state` before the first start.
 - **Back up the wallet:** the only data worth backing up is the `z3-<network>-zallet` volume. It holds both the encrypted wallet database and the age identity that decrypts it, so the volume is self-contained. Chain state is re-syncable and the cookie is regenerated, so neither needs backup.
-- **Stop vs wipe:** `docker compose --env-file .env.<network> down` stops the stack and keeps every volume; adding `-v` (`down -v`) deletes them, which means a full re-sync.
+- **Stop vs wipe:** `docker compose --env-file .env.<network> --profile "*" down` stops the stack and keeps every volume; adding `-v` (`down -v`) deletes them, which means a full re-sync. `--profile "*"` includes profile-gated services (indexer, monitoring); without it their containers keep running and `down -v` leaves their volumes behind.
 
 The volume table and bind-mount details are in the [Reference](#reference) section.
 
@@ -106,11 +106,22 @@ docker compose --env-file .env.<network> --profile monitoring up -d
 
 Default UI host ports are globally unique across the three networks (mainnet Grafana `3000`, testnet `13000`, regtest `23000`, and so on). Each is overridable: `Z3_GRAFANA_PORT`, `Z3_PROMETHEUS_PORT`, `Z3_ALERTMANAGER_PORT`, `Z3_JAEGER_UI_PORT`.
 
+### Indexer
+
+The Zaino indexer ships behind a Compose profile. It adds a lightwalletd-compatible gRPC endpoint (mainnet `8137`) and a JSON-RPC proxy (mainnet `8237`) for explorers, faucets, and light-wallet backends. Zallet reaches Zebra directly, so the default stack does not need it.
+
+```bash
+docker compose --env-file .env.<network> --profile indexer up -d
+```
+
+> [!NOTE]
+> The pinned `zingodevops/zainod` release cannot parse Zebra `6.0.0-rc.0` RPC responses. Until upstream ships Ironwood support, run the indexer profile against a Zebra 5.2-era image by setting `Z3_ZEBRA_IMAGE=zfnd/zebra:5.2.0`.
+
 ### Stopping the stack
 
 ```bash
-docker compose --env-file .env.mainnet down       # stop containers, keep data
-docker compose --env-file .env.mainnet down -v    # stop and delete all volumes (full reset)
+docker compose --env-file .env.mainnet --profile "*" down       # stop containers, keep data
+docker compose --env-file .env.mainnet --profile "*" down -v    # stop and delete all volumes (full reset)
 ```
 
 ## Building and testing against Z3
@@ -138,7 +149,7 @@ Mainnet pairs cleanly with either other network on one host. Testnet and regtest
 graph LR
     subgraph Z3["Z3 (per network)"]
         Zebra["Zebra<br/>(full node)"]
-        Zaino["Zaino<br/>(indexer)"]
+        Zaino["Zaino<br/>(indexer, opt-in)"]
 
         subgraph Zallet["Zallet (wallet)"]
             EmbeddedZaino["Embedded<br/>Zaino libs"]
@@ -150,7 +161,7 @@ graph LR
     Zaino -->|gRPC| LightClients["Light wallet<br/>clients"]
 ```
 
-**Zebra** syncs and validates the Zcash blockchain. **Zaino** provides a lightwalletd-compatible gRPC interface for light wallet clients. **Zallet** embeds Zaino's indexer libraries internally and connects directly to Zebra's JSON-RPC; it does not use the standalone Zaino service. The Zallet image also ships a zebra-state backend binary, but z3 runs the `zallet-zaino` binary.
+**Zebra** syncs and validates the Zcash blockchain. **Zallet** embeds Zaino's indexer libraries internally and connects directly to Zebra's JSON-RPC; it does not use the standalone Zaino service. The Zallet image also ships a zebra-state backend binary, but z3 runs the `zallet-zaino` binary. **Zaino** is optional, behind the `indexer` profile: it exposes a standalone lightwalletd-compatible gRPC interface for external light wallet clients.
 
 Image pins live as `${VAR:-tag}` defaults in `docker-compose.yml`; override any pin with `Z3_ZEBRA_IMAGE`, `Z3_ZAINO_IMAGE`, or `Z3_ZALLET_IMAGE`. Upstream sources: [Zebra](https://github.com/ZcashFoundation/zebra), [Zaino](https://github.com/zingolabs/zaino), [Zallet](https://github.com/zcash/wallet).
 
@@ -163,8 +174,8 @@ Published host ports are chosen per `.env.<network>` so all networks coexist on 
 | Zebra RPC | `http://localhost:<port>` | `Z3_ZEBRA_HOST_RPC_PORT` |
 | Zebra p2p (inbound peers) | `localhost:<port>` | `Z3_ZEBRA_HOST_P2P_PORT` |
 | Zebra health | `http://localhost:<port>/ready` | `Z3_ZEBRA_HOST_HEALTH_PORT` |
-| Zaino gRPC (plaintext, no TLS) | `localhost:<port>` | `Z3_ZAINO_HOST_GRPC_PORT` |
-| Zaino JSON-RPC | `http://localhost:<port>` | `Z3_ZAINO_HOST_JSON_RPC_PORT` |
+| Zaino gRPC (plaintext, no TLS; indexer profile) | `localhost:<port>` | `Z3_ZAINO_HOST_GRPC_PORT` |
+| Zaino JSON-RPC (indexer profile) | `http://localhost:<port>` | `Z3_ZAINO_HOST_JSON_RPC_PORT` |
 | Zallet RPC | `http://localhost:<port>` | `Z3_ZALLET_HOST_RPC_PORT` |
 
 Inside the network, services resolve by DNS name (`zebra`, `zaino`, `zallet`) on Zebra's per-network container ports.
@@ -261,14 +272,14 @@ diff config/mainnet/zallet.toml config/mainnet/zallet.toml.example
 
 ### Platform configuration (ARM64)
 
-Zebra is multi-arch; Docker picks the host's native arch automatically, no override needed. Zaino and Zallet are pinned to `linux/amd64` because their upstream images publish amd64 only. On Apple Silicon those two run under emulation by default; the workload is light enough that this rarely matters.
+Zebra and Zallet are multi-arch; Docker picks the host's native arch automatically, no override needed. Zaino is pinned to `linux/amd64` because its upstream image publishes amd64 only. On Apple Silicon it runs under emulation by default; the workload is light enough that this rarely matters.
 
-To run Zaino and Zallet natively on arm64, build them from source:
+To run Zaino natively on arm64, build it from source:
 
 ```bash
-scripts/vendor.sh zaino zallet
-DOCKER_PLATFORM=linux/arm64 docker compose -f docker-compose.yml -f docker-compose.build.yml build zaino zallet
-docker compose --env-file .env.mainnet up -d
+scripts/vendor.sh zaino
+DOCKER_PLATFORM=linux/arm64 docker compose -f docker-compose.yml -f docker-compose.build.yml build zaino
+docker compose --env-file .env.mainnet --profile indexer up -d
 ```
 
 </details>
@@ -307,7 +318,7 @@ Z3_ZEBRA_RUST_LOG=debug
 Z3_ZAINO_RUST_LOG=debug
 
 # Pin a different image version, or use zfnd/zebra:latest to track Zebra releases
-Z3_ZEBRA_IMAGE=zfnd/zebra:5.0.0
+Z3_ZEBRA_IMAGE=zfnd/zebra:5.2.0
 
 # Move chain state to an external SSD
 Z3_CHAIN_DATA_PATH=/mnt/ssd/zebra-state
@@ -330,7 +341,7 @@ Z3 declares each volume with an explicit `name:` so the external Docker identifi
 | Suffix | Contents |
 |--------|----------|
 | `chain` | Zebra blockchain state (~300 GB mainnet, ~30 GB testnet) |
-| `zaino` | Zaino indexer database |
+| `zaino` | Zaino indexer database (indexer profile) |
 | `zallet` | Zallet wallet database (contains keys) |
 | `cookie` | RPC authentication cookie for mainnet/testnet (regtest disables cookie auth) |
 
@@ -385,11 +396,11 @@ Zebra exposes two endpoints on its health port:
 ```
 Zebra (/ready: synced near tip)
   -> Cookie permissions (.cookie readable on cookie-auth networks)
-  -> Zaino (gRPC port responding)
   -> Zallet (RPC responding)
+  -> Zaino (gRPC port responding; indexer profile)
 ```
 
-The default compose gates Zaino and Zallet on Zebra's `/ready` endpoint and on the cookie-permissions sidecar when cookie auth is enabled. For development, copy `docker-compose.override.yml.example` to `docker-compose.override.yml` to switch Zebra gating to `/healthy` (allows services to start during sync, but they may error until Zebra catches up).
+The default compose gates Zallet on Zebra's `/ready` endpoint and on the cookie-permissions sidecar when cookie auth is enabled; the indexer profile adds Zaino under the same gates. For development, copy `docker-compose.override.yml.example` to `docker-compose.override.yml` to switch Zebra gating to `/healthy` (allows services to start during sync, but they may error until Zebra catches up).
 
 ### Monitoring sync progress
 

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -43,7 +43,6 @@ services:
       ZAINO_NETWORK: Regtest
       ZAINO_VALIDATOR_SETTINGS__VALIDATOR_JSONRPC_LISTEN_ADDRESS: zebra:${Z3_ZEBRA_RPC_PORT:-18232}
       ZAINO_GRPC_SETTINGS__LISTEN_ADDRESS: 0.0.0.0:8137
-      ZAINO_JSON_SERVER_SETTINGS__JSON_RPC_LISTEN_ADDRESS: 0.0.0.0:8237
     volumes: !override
       - ${Z3_ZAINO_DATA_PATH:-zaino}:/app/data
       - ${Z3_CONFIG_DIR:-./config/regtest}/zaino.toml:/etc/zaino/zindexer.toml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ x-common: &common
 
 services:
   zebra:
-    image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:5.0.0}
+    image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:6.0.0-rc.0}
     # Zebra is multi-arch; Docker selects the host's native variant.
     # DOCKER_PLATFORM forces a specific arch for cross-architecture testing.
     platform: ${DOCKER_PLATFORM:-}
@@ -112,10 +112,14 @@ services:
       start_period: 5s
 
   zaino:
+    # Opt-in via --profile indexer. The pinned zainod parses only a Zebra
+    # 5.2-era RPC surface; override Z3_ZEBRA_IMAGE to a 5.2 Zebra until upstream
+    # adds Ironwood support for Zebra 6.
+    profiles: [indexer]
     # The -no-tls tag compiles out Zaino's "TLS required on a non-private bind"
     # guard, so intra-container gRPC on 0.0.0.0:8137 runs as plaintext h2c.
     # Terminate edge TLS at a reverse proxy if Zaino is exposed beyond the host.
-    image: ${Z3_ZAINO_IMAGE:-zingodevops/zainod:0.4.0-rc.2-no-tls}
+    image: ${Z3_ZAINO_IMAGE:-zingodevops/zainod:0.5.1-no-tls}
     # Zaino publishes linux/amd64 only; arm64 hosts run under emulation unless
     # the operator builds from source (see docker-compose.build.yml).
     platform: ${DOCKER_PLATFORM:-linux/amd64}
@@ -123,6 +127,16 @@ services:
     stop_grace_period: 15s
     <<: *common
     cap_add: [CHOWN, DAC_OVERRIDE, FOWNER, SETUID, SETGID]
+    # Zaino refuses to bind its unencrypted JSON-RPC server to non-private
+    # addresses (only a source build with allow_unencrypted_public_json_rpc_bind
+    # lifts that). Bind to the container's own RFC1918 IP instead of 0.0.0.0;
+    # published host ports and service-DNS access are unaffected because Docker
+    # forwards both to the container IP.
+    entrypoint:
+      - bash
+      - -c
+      - ip="$$(getent ahostsv4 "$$HOSTNAME")"; ip="$${ip%% *}"; export ZAINO_JSON_SERVER_SETTINGS__JSON_RPC_LISTEN_ADDRESS="$${ZAINO_JSON_SERVER_SETTINGS__JSON_RPC_LISTEN_ADDRESS:-$${ip}:8237}"; exec /entrypoint.sh "$$@"
+      - --
     command: ["start", "--config", "/etc/zaino/zindexer.toml"]
     depends_on:
       zebra:
@@ -136,7 +150,6 @@ services:
       ZAINO_VALIDATOR_SETTINGS__VALIDATOR_JSONRPC_LISTEN_ADDRESS: zebra:${Z3_ZEBRA_RPC_PORT:-8232}
       ZAINO_VALIDATOR_SETTINGS__VALIDATOR_COOKIE_PATH: /var/run/auth/.cookie
       ZAINO_GRPC_SETTINGS__LISTEN_ADDRESS: 0.0.0.0:8137
-      ZAINO_JSON_SERVER_SETTINGS__JSON_RPC_LISTEN_ADDRESS: 0.0.0.0:8237
     volumes:
       - ${Z3_ZAINO_DATA_PATH:-zaino}:/app/data
       - ${Z3_COOKIE_PATH:-cookie}:/var/run/auth:ro
@@ -153,10 +166,13 @@ services:
       start_interval: 5s
 
   zallet:
-    image: ${Z3_ZALLET_IMAGE:-zodlinc/zallet:v0.1.0-alpha.4}
-    # The alpha.4 image includes multiple binaries. z3 uses the Zaino-backed
-    # wallet binary; it is currently published for amd64 only.
-    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    # Pinned by digest: upstream re-points the v0.1.0-alpha.4 tag at new builds,
+    # and a silently swapped build can reject the existing wallet database.
+    image: ${Z3_ZALLET_IMAGE:-zodlinc/zallet:v0.1.0-alpha.4@sha256:3097751a2502857294d7031a360023834b53a6ebd31ed4520f6cd3a148074dbf}
+    # The image is multi-arch and ships multiple binaries; z3 uses the
+    # Zaino-backed wallet binary. Docker selects the host's native variant.
+    # DOCKER_PLATFORM forces a specific arch for cross-architecture testing.
+    platform: ${DOCKER_PLATFORM:-}
     restart: unless-stopped
     stop_grace_period: 15s
     <<: *common

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -8,7 +8,7 @@ For copy-paste integration examples, see [`docs/integrations/`](integrations/).
 
 ## Stability promise
 
-Identifiers in the contract are SemVer-stable. The shipped contract version is `1.0.0`:
+Identifiers in the contract are SemVer-stable. The shipped contract version is `2.0.0`:
 
 - **Patch** (1.0.x): documentation-only changes; no consumer impact.
 - **Minor** (1.x.0): adds optional fields, new env vars, new optional services. Existing consumers continue working.
@@ -36,7 +36,7 @@ Of these, `cookie` is part of the consumer-facing attachment surface only when t
 
 ### In-network DNS
 
-Inside the Docker network, services resolve at their bare service name (`zebra`, `zaino`, `zallet`). The YAML's `service_dns:` block carries the full list.
+Inside the Docker network, services resolve at their bare service name (`zebra`, `zaino`, `zallet`). The YAML's `service_dns:` block carries the full list. `zaino` resolves only when the `indexer` profile is active; its entry carries a `profile:` field.
 
 No per-network suffix: the network itself is the discriminator. A consumer attached to `z3-testnet` uses `http://zebra:18232`; on `z3-mainnet` it uses `http://zebra:8232`.
 
@@ -82,7 +82,7 @@ For the canonical machine-readable inventory (every variable, its namespace tag,
 
 ### Profiles
 
-One Compose profile is available across every network: `monitoring` (Prometheus, Grafana, Jaeger, AlertManager). Enable with `docker compose --env-file .env.<network> --profile monitoring up -d`. Profile-gated identifiers in the YAML carry an explicit `profile:` field.
+Two Compose profiles are available across every network. `monitoring` adds Prometheus, Grafana, Jaeger, and AlertManager. `indexer` adds the Zaino indexer (lightwalletd-compatible gRPC plus a JSON-RPC proxy) for explorers, faucets, and light-client backends. Enable with `docker compose --env-file .env.<network> --profile <name> up -d`. Profile-gated identifiers in the YAML (Zaino's DNS name, volume, ports, healthcheck, and env vars) carry an explicit `profile:` field.
 
 ## What z3 does NOT publish
 

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -7,7 +7,7 @@ For the public contract (network names, volume names, port matrix), see [`contra
 ## Overview
 
 ```text
-docker-compose.yml              Base stack (Zebra + Zaino + Zallet + optional profiles)
+docker-compose.yml              Base stack (Zebra + Zallet; Zaino under the indexer profile; optional monitoring profile)
 docker-compose.regtest.yml      Regtest overlay (structural differences only)
 docker-compose.build.yml        Opt-in source-build overlay (scripts/vendor.sh)
 .env.mainnet                    Mainnet selection + canonical ports
@@ -28,7 +28,7 @@ The core principle: **`docker-compose.yml` is self-sufficient for mainnet**. Eve
 Every variable reference in `docker-compose.yml` includes a default value:
 
 ```yaml
-image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:5.0.0}
+image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:6.0.0-rc.0}
 environment:
   ZEBRA_NETWORK__NETWORK: ${Z3_NETWORK:-Mainnet}
 volumes:
@@ -266,7 +266,7 @@ Zebra writes the RPC cookie at `/var/run/auth/.cookie` with mode `0600` owned by
 
 The base compose includes a small `cookie-permissions` sidecar (`alpine:3` with `cap_add: [FOWNER]`) that polls every 5 seconds and chmods the cookie to `0644` once it appears. The cookie volume is already the consumer attachment surface, so loosening the file mode within that volume does not change the security boundary; anyone with access to mount the volume already has access to the cookie.
 
-Zaino and Zallet depend on the sidecar's healthcheck, so targeted starts such as `docker compose up -d zaino` also start the sidecar and wait until the cookie is readable. On mainnet and testnet the healthcheck waits for `/var/run/auth/.cookie`; on regtest it exits successfully because cookie auth is disabled and username/password auth is used instead.
+Zallet (and Zaino under the indexer profile) depends on the sidecar's healthcheck, so a targeted start such as `docker compose up -d zallet` also starts the sidecar and waits until the cookie is readable. On mainnet and testnet the healthcheck waits for `/var/run/auth/.cookie`; on regtest it exits successfully because cookie auth is disabled and username/password auth is used instead.
 
 ## Zallet config readability and operator uid
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,9 +17,9 @@ When an entry says "see README", the fix lives there; this FAQ only adds the dia
 
 That's the `/ready` probe doing its job, not a fault. `/ready` requires the node to have at least `ZEBRA_HEALTH__MIN_CONNECTED_PEERS` (default `1`) and to be within `ZEBRA_HEALTH__READY_MAX_BLOCKS_BEHIND` (default `2`) of the network tip. A fresh start from a cold chain, or a restart on a cache that's a few minutes behind, will report `unhealthy` until both thresholds are met.
 
-For development, `/healthy` is a looser signal that only checks peer connectivity. The tracked `docker-compose.override.yml.example` flips the healthcheck to `/healthy` so Zaino and Zallet can start without waiting for full sync. Use it for dev, never for production where you want consumers to wait for a synced node.
+For development, `/healthy` is a looser signal that only checks peer connectivity. The tracked `docker-compose.override.yml.example` flips the healthcheck to `/healthy` so Zallet (and Zaino under the indexer profile) can start without waiting for full sync. Use it for dev, never for production where you want consumers to wait for a synced node.
 
-Don't run `docker compose up -d` (it starts Zaino and Zallet) until Zebra reports `/ready`. The poller `scripts/check-zebra-readiness.sh` waits for exactly that. README Quick start step 3 explains the two-phase boot.
+Don't run `docker compose up -d` (it starts Zallet) until Zebra reports `/ready`. The poller `scripts/check-zebra-readiness.sh` waits for exactly that. README Quick start step 3 explains the two-phase boot.
 
 ---
 
@@ -35,13 +35,13 @@ To keep it off the OS disk, set `Z3_CHAIN_DATA_PATH=/mnt/ssd/zebra-state` and ru
 
 For backups, the only thing worth keeping is the `z3-<network>-zallet` volume. It holds the age-encrypted wallet database **and** the identity that decrypts it, so the volume is self-contained: restore it and the wallet opens. Chain state is re-syncable and the RPC cookie is regenerated on boot, so neither belongs in a backup.
 
-`docker compose --env-file .env.<network> down` keeps all volumes; `down -v` deletes them and forces a full re-sync.
+`docker compose --env-file .env.<network> --profile "*" down` keeps all volumes; `down -v` deletes them and forces a full re-sync. Include `--profile "*"` so profile-gated services (indexer, monitoring) are stopped too.
 
 ---
 
 ### Q: How do I set up the Zallet wallet on mainnet or testnet?
 
-`scripts/regtest-init.sh` initializes the regtest wallet automatically. On mainnet and testnet, the node and indexer run fine without a wallet; initialize Zallet's wallet encryption yourself, once per network, when you are ready to manage keys. Zallet runs as uid 1000 but the distroless image ships no data directory, so a freshly created volume is root-owned: make it writable once, then generate the identity and initialize encryption:
+`scripts/regtest-init.sh` initializes the regtest wallet automatically. On mainnet and testnet, the node runs fine without an initialized wallet; set up Zallet's wallet encryption yourself, once per network, when you are ready to manage keys. Zallet runs as uid 1000 but the distroless image ships no data directory, so a freshly created volume is root-owned: make it writable once, then generate the identity and initialize encryption:
 
 ```bash
 # One-time: make the data volume writable by Zallet's uid (1000).
@@ -127,7 +127,8 @@ The same override pattern works for other services through `Z3_ZAINO_IMAGE` and 
 Overrides are opt-in. A fresh clone boots with no override file, so nothing breaks before you run any setup.
 
 - **Mainnet:** Compose natively auto-loads `docker-compose.override.yml` when it is present and you pass no `-f` or `COMPOSE_FILE`. An absent file is not an error.
-- **Testnet and regtest:** `.env.<network>` sets `COMPOSE_FILE=docker-compose.yml:docker-compose.<network>.yml`, with no override entry, so the stack renders on a fresh clone. To add per-host customizations (pinning Zebra to `linux/arm64`, adding `deploy.resources.limits`), create `docker-compose.<network>.override.yml` and load it explicitly, either by passing `-f docker-compose.yml -f docker-compose.<network>.yml -f docker-compose.<network>.override.yml`, or by appending the override to `COMPOSE_FILE` in your operator-local `.env`.
+- **Testnet:** No network overlay exists; `.env.testnet` sets `COMPOSE_FILE=docker-compose.yml`, so the stack renders on a fresh clone. To add per-host customizations (pinning Zebra to `linux/arm64`, adding `deploy.resources.limits`), create `docker-compose.testnet.override.yml` and load it explicitly, either by passing `-f docker-compose.yml -f docker-compose.testnet.override.yml`, or by appending the override to `COMPOSE_FILE` in your operator-local `.env`.
+- **Regtest:** `.env.regtest` sets `COMPOSE_FILE=docker-compose.yml:docker-compose.regtest.yml` to layer the regtest overlay (adds `rpc-router` and regtest-only settings) on a fresh clone. Per-host customizations work the same way as testnet: create `docker-compose.regtest.override.yml` and either pass it with `-f` or append it to `COMPOSE_FILE`.
 
 The compose merge order is left-to-right, so the override comes last and wins. The live override file is gitignored, so `git pull` never touches it.
 
@@ -163,20 +164,20 @@ docker exec z3-mainnet-zebra-1 uname -m              # aarch64 = native, x86_64 
 docker top z3-mainnet-zebra-1 -o cmd | head -3       # /usr/bin/qemu-x86_64 wrapper = emulated
 ```
 
-Zaino and Zallet are pinned to amd64 by default (their upstream images publish amd64 only) and run under emulation; the workload is light enough that the CPU drain is barely noticeable next to Zebra's verifier.
+Zaino is pinned to amd64 by default (its upstream image publishes amd64 only) and runs under emulation; the workload is light enough that the CPU drain is barely noticeable next to Zebra's verifier. Zallet is multi-arch and runs natively.
 
 ---
 
-### Q: Can I run Zaino or Zallet natively on Apple Silicon?
+### Q: Can I run Zaino natively on Apple Silicon?
 
-Not from the pinned tags. The default Zaino and Zallet images publish `linux/amd64` only (declared in [`z3-contract.yaml`](../z3-contract.yaml) under `image_platforms:`). Confirm with `docker buildx imagetools inspect <image>`. The `unknown/unknown` entries in that output are OCI attestation manifests (SBOM/provenance), not real platform variants.
+Not from the pinned tag. The default Zaino image publishes `linux/amd64` only (declared in [`z3-contract.yaml`](../z3-contract.yaml) under `image_platforms:`). Confirm with `docker buildx imagetools inspect <image>`. The `unknown/unknown` entries in that output are OCI attestation manifests (SBOM/provenance), not real platform variants.
 
 Two ways forward if you need native arm64:
 
-1. **Build locally.** Fetch the upstream sources with `scripts/vendor.sh zaino zallet`, then build with the opt-in overlay: `DOCKER_PLATFORM=linux/arm64 docker compose -f docker-compose.yml -f docker-compose.build.yml build zaino zallet`.
+1. **Build locally.** Fetch the upstream source with `scripts/vendor.sh zaino`, then build with the opt-in overlay: `DOCKER_PLATFORM=linux/arm64 docker compose -f docker-compose.yml -f docker-compose.build.yml build zaino`.
 2. **Wait for the upstream tag to gain a multi-arch publish, then bump the pin.** Existing tags never gain new platform variants after the fact; only new tags do.
 
-Leaving these two services under emulation is fine in practice; the workload is light compared to Zebra's verifier, which runs natively.
+Leaving Zaino under emulation is fine in practice; the workload is light compared to Zebra's verifier, which runs natively. Zaino only runs under the `indexer` profile, so the default stack is unaffected either way.
 
 Zaino's canonical upstream is [zingolabs/zaino](https://github.com/zingolabs/zaino), published to Docker Hub as `zingodevops/zainod` (matching the daemon binary name). `zingodevops/zaino` is an alias publishing identical digests.
 
@@ -212,7 +213,7 @@ If you can't control the consumer, the next lever is compose-level CPU limits (t
 
 Because regtest is meant to look like classic local dev, where username/password auth is the convention every existing tutorial and client library assumes. The regtest overlay (`docker-compose.regtest.yml`) disables Zebra's cookie auth and adds an `rpc-router` sidecar that authenticates with `zebra` / `zebra` against Zebra, so the same RPC client works without juggling cookie files.
 
-Cookie auth stays the default for mainnet and testnet, where Zaino and Zallet read the shared cookie volume directly. See [docs/regtest.md](regtest.md) for the full regtest workflow and the curl/grpcurl examples that use the regtest credentials.
+Cookie auth stays the default for mainnet and testnet, where Zallet (and Zaino under the indexer profile) reads the shared cookie volume directly. See [docs/regtest.md](regtest.md) for the full regtest workflow and the curl/grpcurl examples that use the regtest credentials.
 
 ---
 

--- a/docs/integrations/compose-peer.md
+++ b/docs/integrations/compose-peer.md
@@ -77,7 +77,7 @@ Z3_ZEBRA_CONTAINER_PORT=18232
 
 Container ports are not host ports. Inside the network, services use Zebra's per-network defaults; Zaino and Zallet container ports do not vary by network. Regtest reuses Zebra's testnet container port, so testnet and regtest share the same in-network address (`zebra:18232`); only their published host ports differ (testnet `18232`, regtest `29232`).
 
-| Network | Zebra RPC | Zaino gRPC | Zallet RPC |
+| Network | Zebra RPC | Zaino gRPC (indexer profile) | Zallet RPC |
 |---------|-----------|-------------|-------------|
 | Mainnet | `zebra:8232` | `zaino:8137` | `zallet:28232` |
 | Testnet | `zebra:18232` | `zaino:8137` | `zallet:28232` |

--- a/docs/integrations/host-side-pointer.md
+++ b/docs/integrations/host-side-pointer.md
@@ -16,8 +16,8 @@ Host ports per network (full matrix in [`z3-contract.yaml`](../../z3-contract.ya
 |---------|---------|---------|---------|
 | Zebra RPC | `http://127.0.0.1:8232` | `http://127.0.0.1:18232` | `http://127.0.0.1:29232` |
 | Zebra `/ready` | `http://127.0.0.1:8080/ready` | `http://127.0.0.1:18080/ready` | `http://127.0.0.1:28080/ready` |
-| Zaino gRPC (plaintext h2c) | `127.0.0.1:8137` | `127.0.0.1:18137` | `127.0.0.1:28137` |
-| Zaino JSON-RPC | `http://127.0.0.1:8237` | `http://127.0.0.1:18237` | `http://127.0.0.1:28237` |
+| Zaino gRPC (plaintext h2c; indexer profile) | `127.0.0.1:8137` | `127.0.0.1:18137` | `127.0.0.1:28137` |
+| Zaino JSON-RPC (indexer profile) | `http://127.0.0.1:8237` | `http://127.0.0.1:18237` | `http://127.0.0.1:28237` |
 | Zallet RPC | `http://127.0.0.1:28232` | `http://127.0.0.1:40232` | `http://127.0.0.1:50232` |
 | rpc-router (regtest only) | n/a | n/a | `http://127.0.0.1:8181` |
 

--- a/docs/integrations/lightwalletd-client.md
+++ b/docs/integrations/lightwalletd-client.md
@@ -2,9 +2,14 @@
 
 Your service is a wallet, block explorer, or scanner that speaks the lightwalletd `CompactTxStreamer` gRPC protocol. Z3's Zaino exposes that protocol as plaintext HTTP/2 (h2c) on the documented port. Terminate TLS at a reverse proxy if you expose Zaino beyond the host (see [Edge TLS in production](#edge-tls-in-production)).
 
+Zaino ships behind the `indexer` Compose profile, so every Z3 command in this guide must include `--profile indexer`. The default Z3 stack does not start Zaino.
+
+> [!NOTE]
+> The pinned `zingodevops/zainod` release cannot parse Zebra `6.0.0-rc.0` RPC responses. Until upstream ships Ironwood support, run the indexer profile against a Zebra 5.2-era image by setting `Z3_ZEBRA_IMAGE=zfnd/zebra:5.2.0` before bringing the stack up.
+
 ## Prerequisites
 
-- A running Z3 stack: `docker compose --env-file .env.<network> up -d` in the Z3 repo.
+- A running Z3 stack with the indexer profile: `docker compose --env-file .env.<network> --profile indexer up -d` in the Z3 repo.
 - A gRPC client for your language (Tonic for Rust, grpcio for Python, grpc-java, etc.) or the `grpcurl` CLI for ad-hoc calls.
 - The lightwalletd / Zaino `.proto` files. Fetch them into the Z3 repo with `scripts/vendor.sh zaino` (`vendor/zaino/zaino-proto/proto/service.proto`).
 

--- a/docs/regtest.md
+++ b/docs/regtest.md
@@ -1,6 +1,6 @@
 # Z3 Regtest Environment
 
-Local end-to-end testing of the full Z3 stack (Zebra, Zaino, Zallet, and the rpc-router) in regtest mode.
+Local end-to-end testing of the Z3 stack (Zebra, Zallet, and the rpc-router, plus the optional Zaino indexer) in regtest mode.
 
 Uses the base `docker-compose.yml` with `docker-compose.regtest.yml` overlay and `.env.regtest` for regtest-specific configuration. Volumes are isolated via `COMPOSE_PROJECT_NAME=z3-regtest`, so regtest data never conflicts with mainnet or testnet.
 
@@ -22,7 +22,7 @@ This will:
 1. Copy the per-network config templates (`zebra.toml`, `zaino.toml`, `zallet.toml`) into live gitignored files
 2. Generate the Zallet encryption identity in-container into the data volume (if not already present)
 3. Generate and inject the Zallet RPC password hash in `config/regtest/zallet.toml`
-4. Start Zebra in regtest mode with the activation heights Zaino expects (Canopy at 1, NU5/Orchard at 2)
+4. Start Zebra in regtest mode with the activation heights in `config/regtest` (Canopy at 1, NU5/Orchard at 2)
 5. Mine 2 blocks to activate Orchard
 6. Initialize the Zallet wallet (`init-wallet-encryption` + `generate-mnemonic`)
 
@@ -40,7 +40,7 @@ From the repo root:
 docker compose --env-file .env.regtest up -d
 ```
 
-Zebra, Zaino, and Zallet use pre-built images. The rpc-router builds from source on first run (takes a few minutes; subsequent runs use the Docker layer cache).
+Zebra and Zallet use pre-built images. The rpc-router builds from source on first run (takes a few minutes; subsequent runs use the Docker layer cache).
 
 > [!NOTE]
 > Regtest host ports are explicit and globally unique so all three networks (mainnet, testnet, regtest) can run concurrently on one host without binding collisions.
@@ -48,7 +48,7 @@ Zebra, Zaino, and Zallet use pre-built images. The rpc-router builds from source
 | Service | Endpoint | Description |
 |---------|----------|-------------|
 | rpc-router | http://localhost:8181 | JSON-RPC router (Zebra + Zallet) |
-| Zaino gRPC | localhost:28137 | lightwalletd-compatible gRPC (plaintext h2c) |
+| Zaino gRPC (indexer profile) | localhost:28137 | lightwalletd-compatible gRPC (plaintext h2c) |
 | Zebra RPC | http://localhost:29232 | Direct Zebra JSON-RPC |
 | Zallet RPC | http://localhost:50232 | Direct Zallet JSON-RPC |
 
@@ -74,6 +74,15 @@ curl -s -X POST -H "Content-Type: application/json" \
 ```
 
 ## Test Zaino gRPC
+
+Zaino ships behind the `indexer` profile, so start it explicitly:
+
+```bash
+docker compose --env-file .env.regtest --profile indexer up -d zaino
+```
+
+> [!NOTE]
+> The pinned `zingodevops/zainod` release cannot parse Zebra `6.0.0-rc.0` RPC responses. Until upstream ships Ironwood support, run the indexer profile against a Zebra 5.2-era image by setting `Z3_ZEBRA_IMAGE=zfnd/zebra:5.2.0` before bringing the stack up.
 
 Zaino exposes the [lightwalletd-compatible gRPC protocol](https://github.com/zcash/lightwalletd/blob/master/walletrpc/service.proto) as plaintext h2c (no TLS). In regtest the host port is `28137` (`Z3_ZAINO_HOST_GRPC_PORT`); the `-plaintext` flag tells grpcurl to skip TLS.
 
@@ -116,10 +125,10 @@ The playground calls `rpc.discover` on `http://127.0.0.1:8181` to load the live 
 
 ```bash
 # Stop containers (keeps volumes/wallet data)
-docker compose --env-file .env.regtest down
+docker compose --env-file .env.regtest --profile "*" down
 
 # Full reset (deletes all regtest data; re-run scripts/regtest-init.sh afterwards)
-docker compose --env-file .env.regtest down -v
+docker compose --env-file .env.regtest --profile "*" down -v
 ```
 
 ## Expected output

--- a/scripts/regtest-init.sh
+++ b/scripts/regtest-init.sh
@@ -42,7 +42,6 @@ set +a
 
 PROJECT="${COMPOSE_PROJECT_NAME:-z3-regtest}"
 ZEBRA_HOST_RPC="${Z3_ZEBRA_HOST_RPC_PORT:-29232}"
-ZAINO_HOST_GRPC="${Z3_ZAINO_HOST_GRPC_PORT:-28137}"
 CONFIG_DIR="${Z3_CONFIG_DIR:-./config/regtest}"
 
 log() {
@@ -155,8 +154,9 @@ if ! docker info > /dev/null 2>&1; then
     COMPOSE="sudo -E $COMPOSE"
 fi
 
-# Clean up any leftover containers from previous runs.
-$COMPOSE down --remove-orphans 2>/dev/null || true
+# Clean up any leftover containers from previous runs. --profile "*" includes
+# profile-gated services (indexer), which a plain down would leave running.
+$COMPOSE --profile "*" down --remove-orphans 2>/dev/null || true
 
 echo "==> Starting Zebra in regtest mode..."
 $COMPOSE up -d zebra
@@ -171,7 +171,7 @@ until curl -sf -X POST \
 done
 echo "   Zebra is ready."
 
-echo "==> Mining 2 blocks (NU5/Orchard activates at height 2 to match Zaino's regtest defaults)..."
+echo "==> Mining 2 blocks (config/regtest activates NU5/Orchard at height 2; zebra.toml and zallet.toml agree)..."
 curl -s -u zebra:zebra \
     -X POST -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","method":"generate","params":[2],"id":1}' \
@@ -184,11 +184,10 @@ ZALLET_VOLUME="${PROJECT}-zallet"
 echo "==> Preparing the Zallet data volume..."
 # The distroless Zallet image runs as uid 1000 but ships no /var/lib/zallet
 # directory, so a freshly created named volume is root-owned and unwritable by
-# the container. Chown it to the Zallet uid, and clear any stale lock/database
-# left by an interrupted run (wallet.db is recreated by init-wallet-encryption;
-# a stale one causes a schema mismatch).
+# the container. Chown it to the Zallet uid, and clear any stale lockfile left
+# by an interrupted run.
 $DOCKER run --rm -v "${ZALLET_VOLUME}:/data" busybox \
-    sh -c 'chown 1000:1000 /data && rm -f /data/.lock /data/wallet.db'
+    sh -c 'chown 1000:1000 /data && rm -f /data/.lock'
 
 # generate-mnemonic stores an age-encrypted file; if one exists the full init
 # sequence has already completed successfully.
@@ -197,6 +196,10 @@ ALREADY_INIT=$($DOCKER run --rm -v "${ZALLET_VOLUME}:/data" busybox \
 if [ "${ALREADY_INIT:-0}" -gt 0 ]; then
     echo "   Wallet already initialized, skipping."
 else
+    # A database left by an interrupted init causes a schema mismatch in
+    # init-wallet-encryption. Clear it only while the wallet is uninitialized,
+    # so re-runs never delete an initialized wallet's database.
+    $DOCKER run --rm -v "${ZALLET_VOLUME}:/data" busybox rm -f /data/wallet.db
     # generate-encryption-identity refuses to overwrite an existing identity,
     # so skip it when a prior interrupted run already wrote one.
     HAVE_IDENTITY=$($DOCKER run --rm -v "${ZALLET_VOLUME}:/data" busybox \
@@ -212,10 +215,9 @@ else
 fi
 
 echo "==> Stopping Zebra (will be restarted by docker compose up -d)..."
-$COMPOSE down
+$COMPOSE --profile "*" down
 
 echo ""
 echo "Wallet initialized. Now run:"
 echo "   docker compose --env-file .env.regtest up -d"
 echo "   Router available at http://127.0.0.1:8181"
-echo "   Zaino gRPC available at 127.0.0.1:${ZAINO_HOST_GRPC}"

--- a/scripts/validate-contract.py
+++ b/scripts/validate-contract.py
@@ -3,7 +3,7 @@
 
 Parses the platform contract's port matrix, volume names, RPC auth mode, and
 service DNS directly from z3-contract.yaml, runs `docker compose --env-file
-.env.<net> --profile monitoring config` for each declared
+.env.<net> --profile monitoring --profile indexer config` for each declared
 network, and asserts that the resolved values match.
 
 Volumes and ports can be plain values or {name, profile} / {container, host,
@@ -73,6 +73,16 @@ def load_contract() -> dict:
     return yaml.safe_load(CONTRACT_FILE.read_text())
 
 
+_ALL_PROFILES: list[str] | None = None
+
+
+def all_profiles() -> list[str]:
+    global _ALL_PROFILES
+    if _ALL_PROFILES is None:
+        _ALL_PROFILES = sorted(load_contract().get("profiles", {}))
+    return _ALL_PROFILES
+
+
 def compose_files_for_network(network_name: str) -> list[str]:
     files = ["docker-compose.yml"]
     overlay = ROOT / f"docker-compose.{network_name}.yml"
@@ -81,11 +91,21 @@ def compose_files_for_network(network_name: str) -> list[str]:
     return files
 
 
-def render_compose(network_name: str, env_file: pathlib.Path) -> str:
+def render_compose(
+    network_name: str, env_file: pathlib.Path, profiles: list[str] | None = None,
+) -> str:
+    """Render `docker compose config`. Defaults to every profile the contract
+    declares; pass profiles=[] to render the default topology with no --profile flags."""
     # Pass -f explicitly so local override files do not affect contract checks.
     compose_args: list[str] = []
     for compose_file in compose_files_for_network(network_name):
         compose_args.extend(["-f", compose_file])
+
+    if profiles is None:
+        profiles = all_profiles()
+    profile_args: list[str] = []
+    for profile in profiles:
+        profile_args.extend(["--profile", profile])
 
     try:
         proc = subprocess.run(
@@ -93,7 +113,7 @@ def render_compose(network_name: str, env_file: pathlib.Path) -> str:
                 "docker", "compose",
                 *compose_args,
                 "--env-file", str(env_file),
-                "--profile", "monitoring",
+                *profile_args,
                 "config",
             ],
             cwd=ROOT, capture_output=True, text=True, check=True,
@@ -214,6 +234,79 @@ def validate_network(asserter: Asserter, network_name: str, spec: dict) -> None:
     )
 
 
+def gated_service_names(contract: dict, profile: str) -> set[str]:
+    return {
+        name for name, entry in contract["service_dns"].items()
+        if isinstance(entry, dict) and entry.get("profile") == profile
+    }
+
+
+def gated_host_ports(spec: dict, profile: str) -> set[int]:
+    return {
+        port_spec["host"]
+        for port_spec in spec["ports"].values()
+        if port_spec.get("profile") == profile and port_spec.get("host") is not None
+    }
+
+
+def gated_volume_names(spec: dict, profile: str) -> set[str]:
+    return {
+        volume_name(vol_entry)
+        for vol_entry in spec["volumes"].values()
+        if isinstance(vol_entry, dict) and vol_entry.get("profile") == profile
+    }
+
+
+def validate_default_excludes_profiled_services(asserter: Asserter, network_name: str,
+                                                spec: dict, contract: dict) -> None:
+    """Assert the default render (no --profile flags) excludes every
+    indexer-gated identifier: service block, host ports, and volume.
+
+    Identifiers are derived from the contract's profile: indexer entries
+    rather than hardcoded, so a future profile-gated service is covered here
+    without a script change.
+    """
+    env_file = ROOT / f".env.{network_name}"
+    if not env_file.exists():
+        print(f"  FAIL: missing {env_file.relative_to(ROOT)}")
+        asserter.failures += 1
+        return
+
+    config = render_compose(network_name, env_file, profiles=[])
+    resolved = yaml.safe_load(config)
+    services = resolved.get("services", {})
+
+    for service in sorted(gated_service_names(contract, "indexer")):
+        if service in services:
+            asserter.fail(f"default render includes profile-gated service {service}")
+        else:
+            print(f"  OK   default render excludes service {service}")
+
+    gated_ports = gated_host_ports(spec, "indexer")
+    rendered_hosts = {
+        int(port["published"])
+        for service_spec in services.values()
+        for port in service_spec.get("ports", [])
+        if port.get("published") is not None
+    }
+    leaked_ports = sorted(gated_ports & rendered_hosts)
+    for port in leaked_ports:
+        asserter.fail(f"default render publishes profile-gated host port {port}")
+    if not leaked_ports:
+        print(f"  OK   default render excludes profile-gated host ports {sorted(gated_ports)}")
+
+    rendered_volume_names = {
+        vol_spec.get("name")
+        for vol_spec in resolved.get("volumes", {}).values()
+        if isinstance(vol_spec, dict)
+    }
+    for volume in sorted(gated_volume_names(spec, "indexer")):
+        if volume in rendered_volume_names:
+            asserter.fail(f"default render includes profile-gated volume {volume}")
+        else:
+            print(f"  OK   default render excludes volume {volume}")
+
+
 def validate_healthchecks(asserter: Asserter, network_name: str,
                           config: str, healthchecks: dict) -> None:
     """Spot-check rendered healthcheck.test shape against contract.healthchecks.
@@ -291,6 +384,10 @@ def main() -> int:
     healthchecks = contract.get("healthchecks", {})
     for net_name, net_spec in contract["networks"].items():
         validate_network(asserter, net_name, net_spec)
+
+        print(f"-- Default topology ({net_name}) --")
+        validate_default_excludes_profiled_services(asserter, net_name, net_spec, contract)
+
         if healthchecks:
             env_file = ROOT / f".env.{net_name}"
             if env_file.exists():

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -19,8 +19,8 @@ declare -A URL=(
   [zallet]="https://github.com/zcash/wallet"
 )
 declare -A REF=(
-  [zebra]="v5.0.0"
-  [zaino]="0.4.0-rc.2"
+  [zebra]="v6.0.0-rc.0"
+  [zaino]="0.5.1"
   [zallet]="v0.1.0-alpha.4"
 )
 

--- a/z3-contract.schema.json
+++ b/z3-contract.schema.json
@@ -87,7 +87,7 @@
   "$defs": {
     "profileName": {
       "type": "string",
-      "enum": ["monitoring"]
+      "enum": ["monitoring", "indexer"]
     },
     "networkName": {
       "type": "string",

--- a/z3-contract.yaml
+++ b/z3-contract.yaml
@@ -12,12 +12,12 @@
 #   docs/contract.md                     concept guide (stability promise, file ownership, .env loading)
 #   docs/integrations/                   integration examples
 
-contract_version: "1.0.0"
+contract_version: "2.0.0"
 
 # Version-bump policy. Independent from the z3 git tag.
 versioning:
   policy: semver
-  major: "Breaking: renamed/removed identifier, port change, removed service"
+  major: "Breaking: renamed/removed identifier, port change, removed service, or an always-on identifier becoming profile-gated"
   minor: "Additive: new optional field, new env var, new optional service"
   patch: "Documentation-only or clarification"
 
@@ -26,7 +26,7 @@ versioning:
 # `profile:` key only resolve when that Compose profile is active.
 service_dns:
   zebra:   {dns: zebra}
-  zaino:   {dns: zaino}
+  zaino:   {dns: zaino, profile: indexer}
   zallet:  {dns: zallet}
 
 # Cookie file path inside containers on networks whose rpc_auth.mode is cookie.
@@ -48,15 +48,15 @@ networks:
     volumes:
       chain:  "z3-mainnet-chain"
       cookie: "z3-mainnet-cookie"
-      zaino:  "z3-mainnet-zaino"
+      zaino:  {name: "z3-mainnet-zaino", profile: indexer}
       zallet: "z3-mainnet-zallet"
     ports:
       zebra_rpc:          {container: 8232,  host: 8232}
       zebra_p2p:          {container: 8233,  host: 8233}     # published for inbound peers
       zebra_health:       {container: 8080,  host: 8080}
       zebra_metrics:      {container: 9999}                 # in-network Prometheus scrape endpoint
-      zaino_grpc:         {container: 8137,  host: 8137}
-      zaino_json_rpc:     {container: 8237,  host: 8237}
+      zaino_grpc:         {container: 8137,  host: 8137,   profile: indexer}
+      zaino_json_rpc:     {container: 8237,  host: 8237,   profile: indexer}
       zallet_rpc:         {container: 28232, host: 28232}
       prometheus:         {container: 9090,  host: 9094,   profile: monitoring}
       grafana:            {container: 3000,  host: 3000,   profile: monitoring}
@@ -75,7 +75,7 @@ networks:
     volumes:
       chain:  "z3-testnet-chain"
       cookie: "z3-testnet-cookie"
-      zaino:  "z3-testnet-zaino"
+      zaino:  {name: "z3-testnet-zaino", profile: indexer}
       zallet: "z3-testnet-zallet"
     ports:
       # Health, Zaino, Zallet host ports use a +10000 offset relative to
@@ -84,8 +84,8 @@ networks:
       zebra_p2p:          {container: 18233, host: 18233}
       zebra_health:       {container: 8080,  host: 18080}
       zebra_metrics:      {container: 9999}
-      zaino_grpc:         {container: 8137,  host: 18137}
-      zaino_json_rpc:     {container: 8237,  host: 18237}
+      zaino_grpc:         {container: 8137,  host: 18137,  profile: indexer}
+      zaino_json_rpc:     {container: 8237,  host: 18237,  profile: indexer}
       zallet_rpc:         {container: 28232, host: 40232}
       prometheus:         {container: 9090,  host: 19094,  profile: monitoring}
       grafana:            {container: 3000,  host: 13000,  profile: monitoring}
@@ -108,7 +108,7 @@ networks:
     volumes:
       chain:  "z3-regtest-chain"
       cookie: "z3-regtest-cookie"
-      zaino:  "z3-regtest-zaino"
+      zaino:  {name: "z3-regtest-zaino", profile: indexer}
       zallet: "z3-regtest-zallet"
     ports:
       # Regtest inherits Zebra's testnet container-port defaults.
@@ -117,8 +117,8 @@ networks:
       zebra_p2p:          {container: 18233}
       zebra_health:       {container: 8080,  host: 28080}
       zebra_metrics:      {container: 9999}
-      zaino_grpc:         {container: 8137,  host: 28137}
-      zaino_json_rpc:     {container: 8237,  host: 28237}
+      zaino_grpc:         {container: 8137,  host: 28137,  profile: indexer}
+      zaino_json_rpc:     {container: 8237,  host: 28237,  profile: indexer}
       zallet_rpc:         {container: 28232, host: 50232}
       rpc_router:         {container: 8181,  host: 8181}
       prometheus:         {container: 9090,  host: 29094,  profile: monitoring}
@@ -140,6 +140,7 @@ healthchecks:
   zaino:
     transport: tcp
     port: 8137
+    profile: indexer
     note: "TCP probe on the gRPC port. Confirms a listener exists; does not validate the gRPC handler. Consumers should not rely on this for production routing decisions."
   zallet:
     transport: none
@@ -170,18 +171,18 @@ env_vars:
     # The env vars below override those defaults at runtime; see image_platforms
     # at the end of this file for per-image platform constraints.
     - {name: Z3_ZEBRA_IMAGE, namespace: z3}
-    - {name: Z3_ZAINO_IMAGE, namespace: z3}
+    - {name: Z3_ZAINO_IMAGE, namespace: z3, profile: indexer}
     - {name: Z3_ZALLET_IMAGE, namespace: z3}
     - {name: Z3_ZEBRA_BUILD_FEATURES, namespace: z3, description: "Build arg when building Zebra from source."}
-    - {name: DOCKER_PLATFORM, namespace: docker, description: "Optional platform pin. Zebra 5.x is multi-arch (no pin needed); Zaino and Zallet's zaino-backed binary publish amd64 only and are pinned in compose. Override to build them native arm64 from source (docker-compose.build.yml)."}
+    - {name: DOCKER_PLATFORM, namespace: docker, description: "Optional platform pin. Zebra and Zallet are multi-arch (no pin needed); Zaino publishes amd64 only and is pinned in compose. Override to build Zaino native arm64 from source (docker-compose.build.yml)."}
 
   ports:
     # Host ports (z3 controls the per-network port matrix; testnet/regtest offset).
     - {name: Z3_ZEBRA_HOST_RPC_PORT, namespace: z3, scope: host}
     - {name: Z3_ZEBRA_HOST_P2P_PORT, namespace: z3, scope: host, description: "Published p2p port for inbound peers (mainnet/testnet; regtest is peerless and omits it)."}
     - {name: Z3_ZEBRA_HOST_HEALTH_PORT, namespace: z3, scope: host}
-    - {name: Z3_ZAINO_HOST_GRPC_PORT, namespace: z3, scope: host}
-    - {name: Z3_ZAINO_HOST_JSON_RPC_PORT, namespace: z3, scope: host}
+    - {name: Z3_ZAINO_HOST_GRPC_PORT, namespace: z3, scope: host, profile: indexer}
+    - {name: Z3_ZAINO_HOST_JSON_RPC_PORT, namespace: z3, scope: host, profile: indexer}
     - {name: Z3_ZALLET_HOST_RPC_PORT, namespace: z3, scope: host}
     - {name: Z3_REGTEST_RPC_ROUTER_HOST_PORT, namespace: z3, scope: host, network: regtest, description: "rpc-router host port (regtest only)."}
     # Container ports: only Zebra's vary per network (upstream Zebra defaults
@@ -193,7 +194,7 @@ env_vars:
 
   paths:
     - {name: Z3_CHAIN_DATA_PATH, namespace: z3, description: "Override chain volume with a bind-mount path."}
-    - {name: Z3_ZAINO_DATA_PATH, namespace: z3}
+    - {name: Z3_ZAINO_DATA_PATH, namespace: z3, profile: indexer}
     - {name: Z3_ZALLET_DATA_PATH, namespace: z3}
     - {name: Z3_COOKIE_PATH, namespace: z3, description: "Override cookie volume (advanced; breaks the shared-volume pattern)."}
 
@@ -213,7 +214,7 @@ env_vars:
     # Z3_<service>_RUST_LOG -> RUST_LOG -> default, so a global RUST_LOG=debug
     # flips the whole stack and per-service overrides still win.
     - {name: Z3_ZEBRA_RUST_LOG, namespace: z3}
-    - {name: Z3_ZAINO_RUST_LOG, namespace: z3}
+    - {name: Z3_ZAINO_RUST_LOG, namespace: z3, profile: indexer}
     - {name: Z3_ZALLET_RUST_LOG, namespace: z3}
     - {name: ZEBRA_TRACING__FILTER, namespace: zebra, description: "Advanced: Zebra's own tracing-subscriber filter (independent of RUST_LOG)."}
 
@@ -244,11 +245,12 @@ ecosystem_vars:
 # Compose profiles available across all networks.
 profiles:
   monitoring: "Prometheus + Grafana + Jaeger + AlertManager"
+  indexer: "Zaino indexer (lightwalletd-compatible gRPC + JSON-RPC proxy) for explorers, faucets, and light-client backends"
 
 # Platform constraints per image. Entries listed as amd64-only run under
 # emulation on arm64 hosts even when DOCKER_PLATFORM=linux/arm64 is set.
-# For native arm64 of Zaino and Zallet's zaino-backed binary, build locally from source (docker-compose.build.yml).
+# For native arm64 of Zaino, build locally from source (docker-compose.build.yml).
 image_platforms:
   zebra:  [linux/amd64, linux/arm64]
   zaino:  [linux/amd64]
-  zallet: [linux/amd64]
+  zallet: [linux/amd64, linux/arm64]


### PR DESCRIPTION
The default `docker compose up -d` now starts Zebra and Zallet only. Zaino moves behind an opt-in `indexer` Compose profile, alongside `monitoring`.

Most operators need a node and a wallet together. A standalone indexer is a narrower case: block explorers, faucets, light-client backends. Gating Zaino on `--profile indexer` matches how `monitoring` works and how the earlier zcashd comparator was scoped, so the common deployment stops paying for a component it does not use.

Two pins move with it. Zebra defaults to `6.0.0-rc.0`, the newest published image. Zallet's upstream image is now multi-arch, so its `linux/amd64` pin is dropped and it runs native on arm64.

The platform contract bumps to **2.0.0**: a service leaves the default topology. Zaino's DNS, per-network volumes, gRPC/JSON-RPC ports, healthcheck, and `Z3_ZAINO_*` vars are tagged `profile: indexer`, and the contract validator renders with the profile enabled so they still verify.

**Reviewer scope note:** the pinned `zainod 0.5.1` cannot yet parse Zebra 6 RPC responses (`valuePools` gained the `ironwood` pool, and its fetch backend expects a fixed five). The indexer profile needs `Z3_ZEBRA_IMAGE` overridden to a 5.2-era Zebra until upstream adds Ironwood support; the README indexer section and the lightwalletd integration guide say so.