### PR TITLE
fix(zallet): prepare data volume before startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,12 +176,25 @@ jobs:
 
       - name: Generate the encryption identity in-container
         # Exercises the real generate-encryption-identity command against the
-        # pinned image and asserts the key lands in the data volume owner-only
-        # (mode 0600). The distroless image ships no data dir, so a fresh named
-        # volume is root-owned; chown it to the zallet uid first, as the init
-        # scripts do.
+        # pinned image and asserts the sidecar prepares the data volume before
+        # the key lands there owner-only (mode 0600).
         run: |
-          docker run --rm -v z3-regtest-zallet:/d busybox chown 1000:1000 /d
+          docker compose --env-file .env.regtest up -d cookie-permissions
+          SIDECAR_ID="$(docker compose --env-file .env.regtest ps -q cookie-permissions)"
+          for i in $(seq 1 15); do
+            if [ "$(docker inspect --format '{{.State.Health.Status}}' "$SIDECAR_ID")" = "healthy" ]; then
+              break
+            fi
+            if [ "$i" -eq 15 ]; then
+              docker compose --env-file .env.regtest logs cookie-permissions
+              exit 1
+            fi
+            sleep 2
+          done
+          OWNER="$(docker run --rm -v z3-regtest-zallet:/d busybox stat -c '%u:%g' /d)"
+          test "$OWNER" = "1000:1000"
+          docker run --rm -v z3-regtest-zallet:/d busybox \
+            test -f /d/.z3-volume-initialized
           docker compose --env-file .env.regtest run --rm --no-deps zallet \
             --datadir /var/lib/zallet --config /etc/zallet/zallet.toml \
             generate-encryption-identity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,25 +78,31 @@ services:
       start_period: 90s
       start_interval: 5s
 
-  # Sidecar: makes Zebra's RPC cookie readable inside the shared auth volume
-  # and supplies the CA bundle omitted from Zallet's distroless beta image.
+  # Sidecar: makes Zebra's RPC cookie readable inside the shared auth volume,
+  # supplies the CA bundle omitted from Zallet's distroless beta image, and
+  # prepares Zallet's data volume for its uid-1000 runtime.
   # Zebra writes /var/run/auth/.cookie with mode 0600 owned by uid 10001;
   # Zaino, Zallet, and attached services may run as different users.
   cookie-permissions:
     image: alpine:3
     restart: unless-stopped
     <<: *common
-    # FOWNER is needed to chmod Zebra's cookie after cap_drop: [ALL].
-    cap_add: [FOWNER]
+    # These are needed to prepare Zallet's volume and chmod Zebra's cookie
+    # after cap_drop: [ALL].
+    cap_add: [CHOWN, DAC_OVERRIDE, FOWNER]
     environment:
       ZEBRA_RPC__ENABLE_COOKIE_AUTH: ${ZEBRA_RPC__ENABLE_COOKIE_AUTH:-true}
     volumes:
       - ${Z3_COOKIE_PATH:-cookie}:/var/run/auth
+      - ${Z3_ZALLET_DATA_PATH:-zallet}:/var/run/zallet-data
       - zallet_ca_certificates:/var/run/zallet-ca
     command:
       - sh
       - -c
       - |
+        set -eu
+        touch /var/run/zallet-data/.z3-volume-initialized
+        chown 1000:1000 /var/run/zallet-data /var/run/zallet-data/.z3-volume-initialized
         cp /etc/ssl/certs/ca-certificates.crt /var/run/zallet-ca/ca-certificates.crt
         while true; do
           if [ -f /var/run/auth/.cookie ]; then
@@ -108,7 +114,7 @@ services:
       zebra:
         condition: service_started
     healthcheck:
-      test: ["CMD-SHELL", "test -s /var/run/zallet-ca/ca-certificates.crt && { [ \"$${ZEBRA_RPC__ENABLE_COOKIE_AUTH:-true}\" = \"false\" ] || test -r /var/run/auth/.cookie; }"]
+      test: ["CMD-SHELL", "test -s /var/run/zallet-ca/ca-certificates.crt && test -f /var/run/zallet-data/.z3-volume-initialized && test \"$$(stat -c '%u:%g' /var/run/zallet-data)\" = \"1000:1000\" && { [ \"$${ZEBRA_RPC__ENABLE_COOKIE_AUTH:-true}\" = \"false\" ] || test -r /var/run/auth/.cookie; }"]
       interval: 5s
       timeout: 2s
       retries: 12

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -150,7 +150,7 @@ Zaino's config is empty for mainnet and testnet (all settings come from env vars
 
 ### Zallet identity files
 
-Each network's age-encryption identity lives inside the `z3-<network>-zallet` data volume at `/var/lib/zallet/identity.txt`. It is generated in-container by `zallet generate-encryption-identity` (run by `scripts/regtest-init.sh` for regtest, or manually on mainnet/testnet; see the README Quick start). Because the container creates it as uid 1000, no host-side permission handling is needed.
+Each network's age-encryption identity lives inside the `z3-<network>-zallet` data volume at `/var/lib/zallet/identity.txt`. It is generated in-container by `zallet-zaino generate-encryption-identity` (run by `scripts/regtest-init.sh` for regtest, or manually on mainnet/testnet; see the README Quick start). The `cookie-permissions` sidecar creates a marker before Zallet's first mount and sets the volume root to uid 1000, preventing Docker from replacing that ownership with platform-specific image-directory metadata. Zallet then creates the identity as uid 1000.
 
 ## Extension fields and YAML anchors
 
@@ -272,7 +272,7 @@ Zallet (and Zaino under the indexer profile) depends on the sidecar's healthchec
 
 Zallet uses a distroless image with no shell, entrypoint script, or Linux capabilities, so the base compose pins it with `user: "1000:1000"` and it runs as that uid from PID 1. Unlike Zebra, which starts with an entrypoint that can prepare filesystem state before dropping privileges, Zallet can only read its bind-mounted host config file — `config/<network>/zallet.toml` → `/etc/zallet/zallet.toml` — if it is readable by uid 1000.
 
-The same "no UID coordination required" property that the cookie sidecar provides applies here: the setup scripts make the generated TOML config readable by service containers regardless of the operator's host uid, and they re-apply that on every run. `scripts/setup-network.sh` keeps generated TOMLs mode `0644`; `scripts/regtest-init.sh` restores `0644` after its `mktemp`+`mv` pwhash rewrite (which would otherwise leave `zallet.toml` mode `0600`). The encryption identity needs none of this: it is generated in-container into the `z3-<network>-zallet` volume by `generate-encryption-identity`, owned by uid 1000, so Zallet reads it without any host ACL. CI runs these setup paths with restrictive host modes, derives Zallet's UID/GID from rendered Compose, verifies a container running as that user can read the bind-mounted `zallet.toml`, and exercises `generate-encryption-identity` to confirm the in-volume key is created owner-only.
+The same "no UID coordination required" property that the cookie sidecar provides applies here: the setup scripts make the generated TOML config readable by service containers regardless of the operator's host uid, and they re-apply that on every run. `scripts/setup-network.sh` keeps generated TOMLs mode `0644`; `scripts/regtest-init.sh` restores `0644` after its `mktemp`+`mv` pwhash rewrite (which would otherwise leave `zallet.toml` mode `0600`). The encryption identity needs no host ACL: the sidecar normalizes the data-volume root to uid 1000, and Zallet creates the identity inside that volume as the same uid. CI runs these setup paths with restrictive host modes, derives Zallet's UID/GID from rendered Compose, verifies a container running as that user can read the bind-mounted `zallet.toml`, verifies the sidecar-owned volume root, and exercises `generate-encryption-identity` to confirm the in-volume key is created owner-only.
 
 ## Regtest overlay constraints
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,11 +41,12 @@ For backups, the only thing worth keeping is the `z3-<network>-zallet` volume. I
 
 ### Q: How do I set up the Zallet wallet on mainnet or testnet?
 
-`scripts/regtest-init.sh` initializes the regtest wallet automatically. On mainnet and testnet, the node runs fine without an initialized wallet; set up Zallet's wallet encryption yourself, once per network, when you are ready to manage keys. Zallet runs as uid 1000 but the distroless image ships no data directory, so a freshly created volume is root-owned: make it writable once, then generate the identity and initialize encryption:
+`scripts/regtest-init.sh` initializes the regtest wallet automatically. On mainnet and testnet, the node runs fine without an initialized wallet; set up Zallet's wallet encryption yourself, once per network, when you are ready to manage keys. A normal stack start prepares the data volume through the `cookie-permissions` sidecar. If you initialize the wallet first with `--no-deps`, prepare the volume explicitly, then generate the identity and initialize encryption:
 
 ```bash
-# One-time: make the data volume writable by Zallet's uid (1000).
-docker run --rm -v z3-<network>-zallet:/data busybox chown 1000:1000 /data
+# One-time preparation for the no-deps path.
+docker run --rm -v z3-<network>-zallet:/data busybox \
+  sh -c 'touch /data/.z3-volume-initialized && chown 1000:1000 /data /data/.z3-volume-initialized'
 
 docker compose --env-file .env.<network> run --rm --no-deps zallet \
   --datadir /var/lib/zallet --config /etc/zallet/zallet.toml generate-encryption-identity
@@ -54,7 +55,7 @@ docker compose --env-file .env.<network> run --rm --no-deps zallet \
   --datadir /var/lib/zallet --config /etc/zallet/zallet.toml init-wallet-encryption
 ```
 
-`--no-deps` skips starting Zebra (encryption setup does not need it). `generate-encryption-identity` writes the age key into the `z3-<network>-zallet` volume and refuses to overwrite an existing identity, so re-running it is safe. Each network keeps its Zallet data in a separate volume, so run this once per network you use. Back up the volume (see the data question above): it holds both the wallet and the identity that decrypts it. Afterwards, use the Zallet RPC or `generate-mnemonic` to create or import keys.
+`--no-deps` skips starting Zebra and the volume-preparation sidecar because encryption setup does not need the node. The zero-byte marker prevents Docker from replacing the prepared ownership with platform-specific image-directory metadata on Zallet's first mount. `generate-encryption-identity` writes the age key into the `z3-<network>-zallet` volume and refuses to overwrite an existing identity, so re-running it is safe. Each network keeps its Zallet data in a separate volume, so run this once per network you use. Back up the volume (see the data question above): it holds both the wallet and the identity that decrypts it. Afterwards, use the Zallet RPC or `generate-mnemonic` to create or import keys.
 
 ---
 

--- a/scripts/regtest-init.sh
+++ b/scripts/regtest-init.sh
@@ -182,12 +182,12 @@ echo "   Blocks mined."
 ZALLET_VOLUME="${PROJECT}-zallet"
 
 echo "==> Preparing the Zallet data volume..."
-# The distroless Zallet image runs as uid 1000 but ships no /var/lib/zallet
-# directory, so a freshly created named volume is root-owned and unwritable by
-# the container. Chown it to the Zallet uid, and clear any stale lockfile left
-# by an interrupted run.
+# The beta.1 arm64 image exposes /var/lib/zallet as root-owned. Keep the volume
+# non-empty so Docker does not copy that directory metadata over the prepared
+# volume on Zallet's first mount, then make it writable by the uid-1000 runtime.
+# Clear any stale lockfile left by an interrupted run.
 $DOCKER run --rm -v "${ZALLET_VOLUME}:/data" busybox \
-    sh -c 'chown 1000:1000 /data && rm -f /data/.lock'
+    sh -c 'touch /data/.z3-volume-initialized && chown 1000:1000 /data /data/.z3-volume-initialized && rm -f /data/.lock'
 
 # generate-mnemonic stores an age-encrypted file; if one exists the full init
 # sequence has already completed successfully.


### PR DESCRIPTION
The Zallet beta.1 arm64 image exposes `/var/lib/zallet` as root-owned. Docker can copy that ownership into a fresh named volume on its first Zallet mount, which prevents the uid-1000 runtime from creating its lockfile or encryption identity.

## What changes

- Extend the existing `cookie-permissions` sidecar to seed and chown the Zallet data volume before Zallet starts, with readiness gated on the resulting ownership.
- Apply the same non-empty-volume invariant to regtest initialization and the documented `--no-deps` wallet setup path.
- Assert the sidecar-owned volume root and owner-only identity mode in the regtest smoke job.
- Document the data-volume ownership boundary and the platform-specific Docker copy behavior.

## Security boundary

The sidecar adds `CHOWN` and `DAC_OVERRIDE` to its existing `FOWNER` capability because it must prepare the mounted Zallet data volume. Its mounts remain limited to the RPC cookie, Zallet data, and generated CA volumes, and Zallet continues to run as `1000:1000` with all capabilities dropped.
