### PR TITLE
chore(deps): bump Zebra to 6.2.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ x-common: &common
 
 services:
   zebra:
-    image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:6.2.0}
+    image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:6.2.3}
     # Zebra is multi-arch; Docker selects the host's native variant.
     # DOCKER_PLATFORM forces a specific arch for cross-architecture testing.
     platform: ${DOCKER_PLATFORM:-}

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -28,7 +28,7 @@ The core principle: **`docker-compose.yml` is self-sufficient for mainnet**. Eve
 Every variable reference in `docker-compose.yml` includes a default value:
 
 ```yaml
-image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:6.2.0}
+image: ${Z3_ZEBRA_IMAGE:-zfnd/zebra:6.2.3}
 environment:
   ZEBRA_NETWORK__NETWORK: ${Z3_NETWORK:-Mainnet}
 volumes:

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -19,7 +19,7 @@ declare -A URL=(
   [zallet]="https://github.com/zcash/zallet"
 )
 declare -A REF=(
-  [zebra]="v6.2.0"
+  [zebra]="v6.2.3"
   [zaino]="0.6.0"
   [zallet]="v0.1.0-beta.1"
 )


### PR DESCRIPTION
## Why

The tracked Z3 Zebra default still points to `6.2.0`, while the latest published stable release is `6.2.3`. This update keeps the stack current without replacing the reproducible version pin with the moving `latest` tag.

## Changes

- Bump the Compose default to `zfnd/zebra:6.2.3`.
- Align the opt-in source-build ref with `v6.2.3`.
- Update the architecture documentation default-image example.